### PR TITLE
Prevent navigation away from character edit with unsaved changes

### DIFF
--- a/Threa/Threa.Client/Components/Pages/Character/CharacterEdit.razor
+++ b/Threa/Threa.Client/Components/Pages/Character/CharacterEdit.razor
@@ -12,6 +12,9 @@
 @inject ViewModel<GameMechanics.CharacterEdit> vm
 @inject IDataPortal<GameMechanics.CharacterEdit> characterPortal
 @inject NavigationManager NavigationManager
+@inject IJSRuntime JSRuntime
+
+@implements IDisposable
 
 <h3>Character Details</h3>
 
@@ -87,6 +90,7 @@ else
 
     private readonly static string[] tabNames = new[] { "Info", "Attributes", "Skills", "Magic", "Items" };
     private string activeTab = tabNames[0];
+    private bool _warningEnabled = false;
 
     private void SelectTab(string tabName)
     {
@@ -98,9 +102,9 @@ else
         // Every page _must_ initialize the state manager
         await StateManager.InitializeAsync();
 
-        vm.Saved += () => NavigationManager.NavigateTo("/player/characters");
-        vm.ModelChanged += async () => await InvokeAsync(() => StateHasChanged());
-        vm.ModelPropertyChanged += async (s, a) => await InvokeAsync(() => StateHasChanged());
+        vm.Saved += OnSaved;
+        vm.ModelChanged += OnModelChanged;
+        vm.ModelPropertyChanged += OnModelPropertyChanged;
 
         if (RenderModeProvider.GetRenderMode(this).IsInteractive())
         {
@@ -113,6 +117,59 @@ else
         }
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await UpdateUnsavedChangesWarning();
+        }
+    }
+
+    private void OnSaved()
+    {
+        _ = DisableUnsavedChangesWarning();
+        NavigationManager.NavigateTo("/player/characters");
+    }
+
+    private async void OnModelChanged()
+    {
+        await InvokeAsync(() => StateHasChanged());
+        await UpdateUnsavedChangesWarning();
+    }
+
+    private async void OnModelPropertyChanged(object? s, System.ComponentModel.PropertyChangedEventArgs a)
+    {
+        await InvokeAsync(() => StateHasChanged());
+        await UpdateUnsavedChangesWarning();
+    }
+
+    private async Task UpdateUnsavedChangesWarning()
+    {
+        if (vm.Model == null) return;
+
+        // Enable warning if there are unsaved changes (new unsaved character or modified existing character)
+        bool hasUnsavedChanges = (vm.Model.IsNew || vm.Model.IsDirty) && !vm.Model.IsBeingSaved;
+
+        if (hasUnsavedChanges && !_warningEnabled)
+        {
+            await JSRuntime.InvokeVoidAsync("unsavedChangesWarning.enable");
+            _warningEnabled = true;
+        }
+        else if (!hasUnsavedChanges && _warningEnabled)
+        {
+            await DisableUnsavedChangesWarning();
+        }
+    }
+
+    private async Task DisableUnsavedChangesWarning()
+    {
+        if (_warningEnabled)
+        {
+            await JSRuntime.InvokeVoidAsync("unsavedChangesWarning.disable");
+            _warningEnabled = false;
+        }
+    }
+
     private async void SaveAsync()
     {
         vm.Model.IsBeingSaved = true;
@@ -121,5 +178,13 @@ else
         await vm.SaveAsync();
         vm.Model.IsBeingSaved = false;
         StateHasChanged();
+    }
+
+    public void Dispose()
+    {
+        vm.Saved -= OnSaved;
+        vm.ModelChanged -= OnModelChanged;
+        vm.ModelPropertyChanged -= OnModelPropertyChanged;
+        _ = DisableUnsavedChangesWarning();
     }
 }

--- a/Threa/Threa/wwwroot/js/theme.js
+++ b/Threa/Threa/wwwroot/js/theme.js
@@ -71,3 +71,39 @@ window.reinitializeTooltipsAfterDelay = function(delayMs) {
         window.initializeTooltips();
     }, delayMs || 100);
 };
+
+// Unsaved Changes Warning
+// Prevents user from navigating away when there are unsaved changes
+
+window.unsavedChangesWarning = {
+    _handler: null,
+    _isEnabled: false,
+
+    // Enable the warning (shows browser dialog when trying to leave)
+    enable: function() {
+        if (this._isEnabled) return;
+
+        this._handler = function(e) {
+            e.preventDefault();
+            // Modern browsers ignore custom messages, but we still need to set returnValue
+            e.returnValue = '';
+            return '';
+        };
+
+        window.addEventListener('beforeunload', this._handler);
+        this._isEnabled = true;
+        console.log('[Threa] Unsaved changes warning enabled');
+    },
+
+    // Disable the warning
+    disable: function() {
+        if (!this._isEnabled) return;
+
+        if (this._handler) {
+            window.removeEventListener('beforeunload', this._handler);
+            this._handler = null;
+        }
+        this._isEnabled = false;
+        console.log('[Threa] Unsaved changes warning disabled');
+    }
+};


### PR DESCRIPTION
## Summary
Implements browser warning when user tries to navigate away or close the page while editing a character with unsaved changes.

## Changes
- Added JavaScript `unsavedChangesWarning` module to `theme.js` that hooks into the browser's `beforeunload` event
- Modified `CharacterEdit.razor` to:
  - Inject `IJSRuntime` for JavaScript interop
  - Implement `IDisposable` to clean up event handlers and warning state
  - Track unsaved changes state using CSLA model's `IsNew` and `IsDirty` properties
  - Enable/disable warning based on unsaved changes state
  - Update warning when model properties change

## Behavior
**Warning is enabled when:**
- Creating a new character (`IsNew = true`)
- Modifying an existing character (`IsDirty = true`)

**Warning is disabled when:**
- Character is successfully saved
- Component is disposed
- No unsaved changes exist

## Test Plan
- [ ] Create a new character, make changes, try to close the browser tab - should show warning
- [ ] Create a new character, make changes, save - should NOT show warning when navigating away
- [ ] Edit existing character, make changes, try to navigate away - should show warning
- [ ] Edit existing character, don't make changes, navigate away - should NOT show warning
- [ ] Edit character, make changes, save - should navigate to character list without warning

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)