### PR TITLE
Fix effects not applying to skill ability scores

### DIFF
--- a/GameMechanics/SkillEdit.cs
+++ b/GameMechanics/SkillEdit.cs
@@ -310,12 +310,21 @@ namespace GameMechanics
 
     public int AbilityScore
     {
-      get => Bonus + GetAttributeBase((CharacterEdit)((IParent)Parent).Parent, PrimaryAttribute);
+      get
+      {
+        var character = (CharacterEdit)((IParent)Parent).Parent;
+        var baseAS = Bonus + GetAttributeBase(character, PrimaryAttribute);
+
+        // Apply ability score modifiers from active effects (wounds, debuffs, etc.)
+        var effectModifier = character.Effects.GetAbilityScoreModifier(Name, PrimaryAttribute, baseAS);
+
+        return baseAS + effectModifier;
+      }
     }
 
     /// <summary>
-    /// Gets the base attribute value for the skill, accounting for 
-    /// low FAT/VIT penalties.
+    /// Gets the base attribute value for the skill, accounting for
+    /// item bonuses, effect attribute modifiers, and low FAT/VIT penalties.
     /// </summary>
     public static int GetAttributeBase(CharacterEdit character, string primaryAttribute)
     {
@@ -323,7 +332,8 @@ namespace GameMechanics
       int sum = 0;
       foreach (var item in attributes)
       {
-        sum += character.GetAttribute(item);
+        // Use GetEffectiveAttribute to include item bonuses and effect attribute modifiers
+        sum += character.GetEffectiveAttribute(item);
       }
       var result = sum / attributes.Length;
       if (character.Fatigue.Value < 1)
@@ -342,7 +352,8 @@ namespace GameMechanics
     }
 
     /// <summary>
-    /// Gets the raw attribute value without FAT/VIT penalties.
+    /// Gets the effective attribute value without FAT/VIT penalties.
+    /// Includes item bonuses and effect attribute modifiers.
     /// Used by the action system which applies penalties separately.
     /// </summary>
     public static int GetRawAttributeValue(CharacterEdit character, string primaryAttribute)
@@ -351,7 +362,8 @@ namespace GameMechanics
       int sum = 0;
       foreach (var item in attributes)
       {
-        sum += character.GetAttribute(item);
+        // Use GetEffectiveAttribute to include item bonuses and effect attribute modifiers
+        sum += character.GetEffectiveAttribute(item);
       }
       return sum / attributes.Length;
     }


### PR DESCRIPTION
## Summary

Fixes the issue where effects (wounds, buffs, debuffs, poisons, etc.) were not being applied to character skill ability scores. The effects system infrastructure was complete, but the `SkillEdit.AbilityScore` property was not calling the modifier aggregation methods.

## Root Cause

The `SkillEdit.AbilityScore` property was calculating:
```csharp
Bonus + GetAttributeBase(character, PrimaryAttribute)
```

But it was missing:
1. Effect AS modifiers (from `Effects.GetAbilityScoreModifier()`)
2. Attribute modifiers from effects (because `GetAttributeBase` used `GetAttribute()` instead of `GetEffectiveAttribute()`)

## Changes

**SkillEdit.cs:**
- `AbilityScore` property now includes effect AS modifiers by calling `character.Effects.GetAbilityScoreModifier()`
- `GetAttributeBase()` now uses `character.GetEffectiveAttribute()` to include item bonuses and effect attribute modifiers
- `GetRawAttributeValue()` also updated for consistency

## What Now Works

- **Wounds**: -2 AS per wound penalty applies to all skill ability scores
- **Spell Buffs**: Global AS bonuses and skill-specific bonuses affect skill AS
- **Attribute Modifiers**: Effects like "+2 STR" or "-5 WIL" now cascade to skill ability scores
- **Poisons**: AS penalties from active poisons affect skills
- **Drugs**: Combat drugs and stimulants apply their bonuses to skill AS
- **Combined Effects**: Multiple effects stack correctly (e.g., wound -2 + buff +3 = net +1)

## Test Plan

Added 4 new integration tests:
- [x] `Skill_AbilityScore_IncludesWoundModifiers` - Verifies wounds apply -4 AS for 2 wounds
- [x] `Skill_AbilityScore_IncludesSpellBuffModifiers` - Verifies global AS buffs work
- [x] `Skill_AbilityScore_IncludesAttributeModifiersFromEffects` - Verifies attribute buffs cascade
- [x] `Skill_AbilityScore_CombinesMultipleEffectModifiers` - Verifies multiple effects combine

All 969 tests pass.

**Manual testing:**
- [ ] Apply a wound to a character, verify skill AS decreases by 2
- [ ] Apply a spell buff (+AS), verify skill AS increases
- [ ] Apply an effect with -5 WIL, verify WIL-based skills show reduced AS
- [ ] Verify the UI reflects the modified ability scores

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)