### PR TITLE
Fix Max AP calculation to use skill levels / 20

### DIFF
--- a/GameMechanics.Test/ActionPointsTests.cs
+++ b/GameMechanics.Test/ActionPointsTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GameMechanics.Test;
+
+[TestClass]
+public class ActionPointsTests
+{
+    [TestMethod]
+    [DataRow(0, 1, DisplayName = "Zero skill levels returns minimum 1")]
+    [DataRow(-5, 1, DisplayName = "Negative skill levels returns minimum 1")]
+    [DataRow(10, 1, DisplayName = "10 skill levels returns 1 (10/20 = 0, but minimum 1)")]
+    [DataRow(19, 1, DisplayName = "19 skill levels returns 1 (19/20 = 0, but minimum 1)")]
+    [DataRow(20, 1, DisplayName = "20 skill levels returns 1 (20/20 = 1)")]
+    [DataRow(21, 1, DisplayName = "21 skill levels returns 1 (21/20 = 1)")]
+    [DataRow(39, 1, DisplayName = "39 skill levels returns 1 (39/20 = 1)")]
+    [DataRow(40, 2, DisplayName = "40 skill levels returns 2 (40/20 = 2)")]
+    [DataRow(47, 2, DisplayName = "47 skill levels returns 2 (47/20 = 2)")]
+    [DataRow(60, 3, DisplayName = "60 skill levels returns 3 (60/20 = 3)")]
+    [DataRow(100, 5, DisplayName = "100 skill levels returns 5 (100/20 = 5)")]
+    [DataRow(120, 6, DisplayName = "120 skill levels returns 6 (120/20 = 6)")]
+    public void CalculateMax_ReturnsExpectedMaxAP(int totalSkillLevels, int expectedMaxAP)
+    {
+        var result = ActionPoints.CalculateMax(totalSkillLevels);
+        Assert.AreEqual(expectedMaxAP, result);
+    }
+
+    [TestMethod]
+    public void CalculateRecovery_ReturnsMinimum1_WhenFatigueLessThan4()
+    {
+        Assert.AreEqual(1, ActionPoints.CalculateRecovery(0));
+        Assert.AreEqual(1, ActionPoints.CalculateRecovery(1));
+        Assert.AreEqual(1, ActionPoints.CalculateRecovery(2));
+        Assert.AreEqual(1, ActionPoints.CalculateRecovery(3));
+    }
+
+    [TestMethod]
+    [DataRow(4, 1, DisplayName = "FAT 4 recovers 1 AP")]
+    [DataRow(8, 2, DisplayName = "FAT 8 recovers 2 AP")]
+    [DataRow(12, 3, DisplayName = "FAT 12 recovers 3 AP")]
+    [DataRow(16, 4, DisplayName = "FAT 16 recovers 4 AP")]
+    [DataRow(20, 5, DisplayName = "FAT 20 recovers 5 AP")]
+    public void CalculateRecovery_ReturnsExpectedRecovery(int fatigue, int expectedRecovery)
+    {
+        var result = ActionPoints.CalculateRecovery(fatigue);
+        Assert.AreEqual(expectedRecovery, result);
+    }
+}

--- a/GameMechanics/ActionPoints.cs
+++ b/GameMechanics/ActionPoints.cs
@@ -127,15 +127,15 @@ namespace GameMechanics
 
     /// <summary>
     /// Calculates maximum AP based on total skill levels.
-    /// 0-10 levels = 1 AP, 11-20 = 2 AP, 21-30 = 3 AP, etc.
+    /// Max AP = TotalSkillLevels / 20 (minimum 1)
     /// </summary>
     /// <param name="totalSkillLevels">Sum of all individual skill levels the character has.</param>
     public static int CalculateMax(int totalSkillLevels)
     {
       if (totalSkillLevels <= 0)
         return 1;
-      // Ceiling division: (n + 9) / 10 gives 1 for 1-10, 2 for 11-20, etc.
-      return (totalSkillLevels + 9) / 10;
+      var result = totalSkillLevels / 20;
+      return result < 1 ? 1 : result;
     }
 
     /// <summary>

--- a/design/ACTION_POINTS.md
+++ b/design/ACTION_POINTS.md
@@ -10,19 +10,15 @@ Action Points (AP) represent a character's capacity to perform actions during co
 
 A character's maximum AP is calculated from their total accumulated skill levels across all skills:
 
-| Total Skill Levels | Max AP |
-|--------------------|--------|
-| 0-10 | 1 |
-| 11-20 | 2 |
-| 21-30 | 3 |
-| 31-40 | 4 |
-| etc. | +1 per 10 levels |
+```
+Max AP = TotalSkillLevels / 20 (minimum 1)
+```
 
 **Examples**:
-- New character with 10 total skill levels: Max AP = 1
-- Developing character with 15 total skill levels: Max AP = 2
-- Experienced character with 47 total skill levels: Max AP = 5
-- Veteran character with 120 total skill levels: Max AP = 12
+- New character with 10 total skill levels: Max AP = 1 (minimum)
+- Developing character with 25 total skill levels: Max AP = 1 (25/20 = 1.25 → 1)
+- Experienced character with 47 total skill levels: Max AP = 2 (47/20 = 2.35 → 2)
+- Veteran character with 120 total skill levels: Max AP = 6 (120/20 = 6)
 
 **Note**: Total Skill Levels is the sum of all individual skill levels the character has, not the count of skills. A character with Swords 3, Dodge 2, and Focus 4 has 9 total skill levels.
 
@@ -185,8 +181,7 @@ Characters can choose to rest instead of taking combat actions:
 ### Calculation Summary
 
 ```
-Max AP = ceiling(TotalSkillLevels / 10), minimum 1
-         (0-10 levels = 1 AP, 11-20 = 2 AP, 21-30 = 3 AP, etc.)
+Max AP = TotalSkillLevels / 20 (minimum 1)
 Recovery = CurrentFAT / 4 (minimum 1)
 Standard Action = 1 AP + 1 FAT
 Fatigue-Free Action = 2 AP


### PR DESCRIPTION
## Summary
- Changed Max AP calculation from `ceiling(skillLevels / 10)` to `skillLevels / 20` (minimum 1)
- Updated design documentation to reflect the new formula
- Added comprehensive unit tests for `CalculateMax` method

Fixes #46

## Test plan
- [x] All existing tests pass (995 tests)
- [x] New ActionPointsTests verify the formula edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)