### PR TITLE
Split play page into character selection and play pages

### DIFF
--- a/Threa/Threa.Client/Components/Pages/GamePlay/GmTable.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/GmTable.razor
@@ -826,7 +826,7 @@ else
     }
 
     private string GetPlayerJoinLink() =>
-        NavigationManager.ToAbsoluteUri($"/play/{TableId}").ToString();
+        NavigationManager.ToAbsoluteUri($"/play/join/{TableId}").ToString();
 
     private string GetStatusBadgeClass() =>
         table?.Status switch

--- a/Threa/Threa.Client/Components/Pages/GamePlay/Play.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/Play.razor
@@ -1,5 +1,5 @@
-@page "/play"
-@page "/play/{TableId:guid}"
+@page "/play/{CharacterId:int}"
+@page "/play/{CharacterId:int}/{TableId:guid}"
 
 @rendermode InteractiveServer
 
@@ -14,13 +14,8 @@
 @inject Csla.Blazor.State.StateManager StateManager
 @inject RenderModeProvider RenderModeProvider
 @inject NavigationManager NavigationManager
-@inject ApplicationContext applicationContext
 @inject IDataPortal<GameMechanics.CharacterEdit> characterPortal
 @inject IDataPortal<GameMechanics.GamePlay.TableEdit> tablePortal
-@inject IDataPortal<GameMechanics.Player.CharacterList> characterListPortal
-@inject IDataPortal<GameMechanics.GamePlay.TableCharacterDetacher> detacherPortal
-@inject IDataPortal<GameMechanics.GamePlay.TableCharacterAttacher> attacherPortal
-@inject IDataPortal<GameMechanics.GamePlay.TableList> tableListPortal
 @inject IActivityLogService ActivityLog
 @inject ITimeEventSubscriber TimeEventSubscriber
 @inject ITimeEventPublisher TimeEventPublisher
@@ -43,178 +38,18 @@
     </div>
 }
 
-@if (table == null && TableId != Guid.Empty)
+@if (isLoading)
 {
-    <div>Loading table...</div>
+    <div>Loading character...</div>
 }
 else if (character == null)
 {
-    <h3>Select a Character to Play</h3>
-
-    @if (availableCharacters == null)
-    {
-        <p>Loading characters...</p>
-    }
-    else if (!availableCharacters.Any())
-    {
-        <div class="alert alert-info">
-            <p>You don't have any activated characters to play.</p>
-            <p><a href="/player/characters">Create and activate a character</a> to start playing.</p>
-        </div>
-    }
-    else
-    {
-        <div class="list-group" style="max-width: 500px;">
-            @foreach (var charInfo in availableCharacters)
-            {
-                <div class="list-group-item d-flex justify-content-between align-items-center">
-                    <div class="d-flex align-items-center gap-2 flex-grow-1" 
-                         style="cursor: pointer;" 
-                         @onclick="() => SelectCharacterAsync(charInfo.Id)">
-                        <div>
-                            <strong>@charInfo.Name</strong>
-                            <br />
-                            <small class="text-muted">@charInfo.Species</small>
-                            @if (charInfo.IsAttachedToTable)
-                            {
-                                <br />
-                                <small class="text-info"><i class="bi bi-table"></i> Table: @charInfo.TableName</small>
-                            }
-                        </div>
-                    </div>
-                    <div class="d-flex gap-2">
-                        @if (charInfo.IsAttachedToTable)
-                        {
-                            <button class="btn btn-sm btn-outline-warning" 
-                                    title="Detach from table"
-                                    @onclick="() => ShowDetachConfirmation(charInfo)"
-                                    @onclick:stopPropagation="true">
-                                <i class="bi bi-box-arrow-right"></i>
-                            </button>
-                        }
-                        <button class="btn btn-sm btn-success" 
-                                @onclick="() => SelectCharacterAsync(charInfo.Id)"
-                                @onclick:stopPropagation="true">
-                            Play
-                        </button>
-                    </div>
-                </div>
-            }
-        </div>
-    }
-}
-
-@* Detach Confirmation Dialog *@
-@if (showDetachConfirmation && characterToDetach != null)
-{
-    <div class="modal fade show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header bg-warning">
-                    <h5 class="modal-title">Confirm Detach from Table</h5>
-                    <button type="button" class="btn-close" @onclick="CancelDetach"></button>
-                </div>
-                <div class="modal-body">
-                    <p>Are you sure you want to detach <strong>@characterToDetach.Name</strong> from table <strong>@characterToDetach.TableName</strong>?</p>
-                    <div class="alert alert-warning">
-                        <i class="bi bi-exclamation-triangle"></i>
-                        <strong>Warning:</strong> This will remove your character from the active game session. 
-                        You will need to rejoin the table to continue playing in that session.
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="CancelDetach">Cancel</button>
-                    <button type="button" class="btn btn-warning" @onclick="ConfirmDetach" disabled="@isDetaching">
-                        @if (isDetaching)
-                        {
-                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                            <span>Detaching...</span>
-                        }
-                        else
-                        {
-                            <span>Detach Character</span>
-                        }
-                    </button>
-                </div>
-            </div>
-        </div>
+    <div class="alert alert-warning">
+        <p>Character not found or you don't have access to play this character.</p>
+        <p><a href="/play">Select a different character</a></p>
     </div>
 }
-
-@* Table Selection Dialog *@
-@if (showTableSelection && characterToAttach != null)
-{
-    <div class="modal fade show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header bg-primary text-white">
-                    <h5 class="modal-title">Join a Table</h5>
-                    <button type="button" class="btn-close btn-close-white" @onclick="CancelTableSelection"></button>
-                </div>
-                <div class="modal-body">
-                    <p>Select a table for <strong>@characterToAttach.Name</strong> to join:</p>
-                    
-                    @if (availableTables == null)
-                    {
-                        <p>Loading tables...</p>
-                    }
-                    else if (!availableTables.Any())
-                    {
-                        <div class="alert alert-info">
-                            <p>No active tables available.</p>
-                            <p>You can still play without joining a table, or ask a Game Master to create one.</p>
-                        </div>
-                    }
-                    else
-                    {
-                        <div class="list-group mb-3">
-                            @foreach (var tableInfo in availableTables)
-                            {
-                                <button type="button" 
-                                        class="list-group-item list-group-item-action d-flex justify-content-between align-items-center @(selectedTableId == tableInfo.Id ? "active" : "")"
-                                        @onclick="() => selectedTableId = tableInfo.Id">
-                                    <div>
-                                        <strong>@tableInfo.Name</strong>
-                                        <br />
-                                        <small>@tableInfo.StatusDisplay - Round @tableInfo.CurrentRound</small>
-                                    </div>
-                                    @if (selectedTableId == tableInfo.Id)
-                                    {
-                                        <i class="bi bi-check-circle-fill"></i>
-                                    }
-                                </button>
-                            }
-                        </div>
-                    }
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="CancelTableSelection">Cancel</button>
-                    <button type="button" class="btn btn-outline-primary" @onclick="PlayWithoutTable">
-                        Play Without Table
-                    </button>
-                    @if (availableTables != null && availableTables.Any())
-                    {
-                        <button type="button" class="btn btn-primary" 
-                                @onclick="ConfirmTableSelection" 
-                                disabled="@(selectedTableId == Guid.Empty || isAttaching)">
-                            @if (isAttaching)
-                            {
-                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                <span>Joining...</span>
-                            }
-                            else
-                            {
-                                <span>Join Table</span>
-                            }
-                        </button>
-                    }
-                </div>
-            </div>
-        </div>
-    </div>
-}
-
-@if (character != null)
+else
 {
     <!-- Character Status Header (themed) -->
     <div class="character-header p-3 rounded mb-3">
@@ -430,8 +265,12 @@ else if (character == null)
 #pragma warning disable CS0618 // Using legacy round-based properties for UI display
 
 [Parameter]
+public int CharacterId { get; set; }
+
+[Parameter]
 public Guid TableId { get; set; }
 
+private bool isLoading = true;
 private static readonly string[] AllTabNames = new[] { "Status", "Combat", "Defense", "Skills", "Magic", "Inventory" };
 private string[] tabNames => GetTabNamesForTheme();
 private string activeTab = "Status";
@@ -458,10 +297,7 @@ private void EnsureValidActiveTab()
 
 private GameMechanics.CharacterEdit? character;
 private GameMechanics.GamePlay.TableEdit? table;
-private IEnumerable<GameMechanics.Player.CharacterInfo>? availableCharacters;
-private IEnumerable<GameMechanics.GamePlay.TableInfo>? availableTables;
 private string? errorMessage;
-private int currentPlayerId;
 private List<ActivityLogEntry> activityLog = new();
 private IDisposable? activityLogSubscription;
 private bool timeEventSubscribed;
@@ -469,17 +305,6 @@ private bool _disposed;
 
 // Semaphore to prevent concurrent processing of time skip messages
 private readonly SemaphoreSlim _timeSkipSemaphore = new(1, 1);
-
-// Detach confirmation state
-private bool showDetachConfirmation;
-private bool isDetaching;
-private GameMechanics.Player.CharacterInfo? characterToDetach;
-
-// Table selection state
-private bool showTableSelection;
-private bool isAttaching;
-private GameMechanics.Player.CharacterInfo? characterToAttach;
-private Guid selectedTableId;
 
 private record ActivityLogEntry(DateTime Timestamp, string Message, string Source, ActivityCategory Category);
 
@@ -489,31 +314,51 @@ protected override async Task OnInitializedAsync()
 
     if (RenderModeProvider.GetRenderMode(this).IsInteractive())
     {
-        // Get the current player ID from claims
-        currentPlayerId = int.Parse(applicationContext.Principal.Claims
-            .Where(_ => _.Type == System.Security.Claims.ClaimTypes.NameIdentifier).First().Value);
-
-        await LoadCharactersAsync();
-
-        // If TableId is provided, load the table
-        if (TableId != Guid.Empty)
+        try
         {
-            try
-            {
-                table = await tablePortal.FetchAsync(TableId);
-                SubscribeToActivityLog(TableId);
-                await SubscribeToTimeEvents(TableId);
+            isLoading = true;
 
-                // Apply the table's theme
-                if (table != null)
+            // Load character directly from URL parameter
+            character = await characterPortal.FetchAsync(CharacterId);
+            await LoadEquippedItemsAsync();
+
+            // If TableId is provided, load the table
+            if (TableId != Guid.Empty)
+            {
+                try
                 {
-                    await JS.InvokeVoidAsync("threaTheme.apply", table.Theme ?? "fantasy");
+                    table = await tablePortal.FetchAsync(TableId);
+                    SubscribeToActivityLog(TableId);
+                    await SubscribeToTimeEvents(TableId);
+
+                    // Apply the table's theme
+                    if (table != null)
+                    {
+                        await JS.InvokeVoidAsync("threaTheme.apply", table.Theme ?? "fantasy");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errorMessage = $"Failed to load table: {ex.Message}";
                 }
             }
-            catch (Exception ex)
+
+            AddLogEntry($"Playing as {character.Name}", ActivityCategory.Player);
+
+            // If joining an in-progress table, announce the current game time
+            if (table != null && table.Status == Threa.Dal.Dto.TableStatus.Active)
             {
-                errorMessage = $"Failed to load table: {ex.Message}";
+                var timeDisplay = TimeFormat.FormatFull(table.CurrentTimeSeconds);
+                AddLogEntry($"The in-game time is: {timeDisplay}", ActivityCategory.Time);
             }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to load character: {ex.Message}";
+        }
+        finally
+        {
+            isLoading = false;
         }
     }
 }
@@ -534,92 +379,11 @@ protected override async Task OnAfterRenderAsync(bool firstRender)
     }
 }
 
-private async Task LoadCharactersAsync()
-{
-    // Load available characters for selection
-    var charList = await characterListPortal.FetchAsync(currentPlayerId);
-    availableCharacters = charList.Where(c => c.IsPlayable);
-}
-
-private async Task LoadTablesAsync()
-{
-    try
-    {
-        var tableList = await tableListPortal.FetchAsync();
-        // Show only active tables (not ended)
-        availableTables = tableList.Where(t => t.Status != Threa.Dal.Dto.TableStatus.Ended);
-    }
-    catch (Exception ex)
-    {
-        errorMessage = $"Failed to load tables: {ex.Message}";
-    }
-}
-
 private async Task LoadEquippedItemsAsync()
 {
     if (character == null) return;
     var equippedItems = await CharacterItemDal.GetEquippedItemsWithTemplatesAsync(character.Id);
     character.SetEquippedItems(equippedItems);
-}
-
-private async Task SelectCharacterAsync(int characterId)
-{
-    try
-    {
-        errorMessage = null;
-        
-        // Find the character info to check if attached to table
-        var charInfo = availableCharacters?.FirstOrDefault(c => c.Id == characterId);
-        
-        if (charInfo != null && !charInfo.IsAttachedToTable)
-        {
-            // Character not attached to a table - show table selection dialog
-            characterToAttach = charInfo;
-            selectedTableId = Guid.Empty;
-            await LoadTablesAsync();
-            showTableSelection = true;
-        }
-        else
-        {
-            // Character is attached to a table or we couldn't find info - just load and play
-            character = await characterPortal.FetchAsync(characterId);
-            await LoadEquippedItemsAsync();
-
-            // If attached to a table, load the table too
-            if (charInfo?.TableId != null)
-            {
-                try
-                {
-                    table = await tablePortal.FetchAsync(charInfo.TableId.Value);
-                    SubscribeToActivityLog(charInfo.TableId.Value);
-                    await SubscribeToTimeEvents(charInfo.TableId.Value);
-
-                    // Apply the table's theme
-                    if (table != null)
-                    {
-                        await JS.InvokeVoidAsync("threaTheme.apply", table.Theme ?? "fantasy");
-                    }
-                }
-                catch
-                {
-                    // Table might not exist anymore - continue without it
-                }
-            }
-
-            AddLogEntry($"Playing as {character.Name}", ActivityCategory.Player);
-
-            // If joining an in-progress table, announce the current game time
-            if (table != null && table.Status == Threa.Dal.Dto.TableStatus.Active)
-            {
-                var timeDisplay = TimeFormat.FormatFull(table.CurrentTimeSeconds);
-                AddLogEntry($"The in-game time is: {timeDisplay}", ActivityCategory.Time);
-            }
-        }
-    }
-    catch (Exception ex)
-    {
-        errorMessage = $"Failed to load character: {ex.Message}";
-    }
 }
 
     private void SelectTab(string tabName)
@@ -946,141 +710,6 @@ private async Task SelectCharacterAsync(int characterId)
         Threa.Dal.Dto.EffectType.ItemEffect => "var(--color-accent-primary)",
         _ => "var(--color-text-primary)"
     };
-
-    // Detach confirmation methods
-    private void ShowDetachConfirmation(GameMechanics.Player.CharacterInfo charInfo)
-    {
-        characterToDetach = charInfo;
-        showDetachConfirmation = true;
-    }
-
-    private void CancelDetach()
-    {
-        showDetachConfirmation = false;
-        characterToDetach = null;
-    }
-
-    private async Task ConfirmDetach()
-    {
-        if (characterToDetach == null) return;
-
-        try
-        {
-            isDetaching = true;
-            errorMessage = null;
-
-            var result = await detacherPortal.ExecuteAsync(characterToDetach.Id);
-
-            if (result.Success)
-            {
-                AddLogEntry($"Detached {characterToDetach.Name} from table {result.TableName}", ActivityCategory.Player);
-
-                // Reload the character list to reflect the change
-                await LoadCharactersAsync();
-            }
-            else
-            {
-                errorMessage = result.ErrorMessage ?? "Failed to detach character from table.";
-            }
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"Failed to detach character: {ex.Message}";
-        }
-        finally
-        {
-            isDetaching = false;
-            showDetachConfirmation = false;
-            characterToDetach = null;
-        }
-    }
-
-    // Table selection methods
-    private void CancelTableSelection()
-    {
-        showTableSelection = false;
-        characterToAttach = null;
-        selectedTableId = Guid.Empty;
-    }
-
-    private async Task PlayWithoutTable()
-    {
-        if (characterToAttach == null) return;
-
-        try
-        {
-            errorMessage = null;
-            character = await characterPortal.FetchAsync(characterToAttach.Id);
-            await LoadEquippedItemsAsync();
-            AddLogEntry($"Playing as {character.Name} (no table)", ActivityCategory.Player);
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"Failed to load character: {ex.Message}";
-        }
-        finally
-        {
-            showTableSelection = false;
-            characterToAttach = null;
-            selectedTableId = Guid.Empty;
-        }
-    }
-
-    private async Task ConfirmTableSelection()
-    {
-        if (characterToAttach == null || selectedTableId == Guid.Empty) return;
-
-        try
-        {
-            isAttaching = true;
-            errorMessage = null;
-
-            var result = await attacherPortal.ExecuteAsync(characterToAttach.Id, selectedTableId, currentPlayerId);
-
-            if (result.Success)
-            {
-                // Load the character and table
-                character = await characterPortal.FetchAsync(characterToAttach.Id);
-                await LoadEquippedItemsAsync();
-                table = await tablePortal.FetchAsync(selectedTableId);
-                SubscribeToActivityLog(selectedTableId);
-                await SubscribeToTimeEvents(selectedTableId);
-
-                // Apply the table's theme
-                if (table != null)
-                {
-                    await JS.InvokeVoidAsync("threaTheme.apply", table.Theme ?? "fantasy");
-                }
-
-                // Reload the character list to reflect the change
-                await LoadCharactersAsync();
-
-                AddLogEntry($"Joined table {result.TableName}", ActivityCategory.Player);
-
-                // If joining an in-progress table, announce the current game time
-                if (table?.Status == Threa.Dal.Dto.TableStatus.Active)
-                {
-                    var timeDisplay = TimeFormat.FormatFull(table.CurrentTimeSeconds);
-                    AddLogEntry($"The in-game time is: {timeDisplay}", ActivityCategory.Time);
-                }
-            }
-            else
-            {
-                errorMessage = result.ErrorMessage ?? "Failed to join table.";
-            }
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"Failed to join table: {ex.Message}";
-        }
-        finally
-        {
-            isAttaching = false;
-            showTableSelection = false;
-            characterToAttach = null;
-            selectedTableId = Guid.Empty;
-        }
-    }
 
     // ================================
     // Concentration Result Processing

--- a/Threa/Threa.Client/Components/Pages/GamePlay/SelectCharacter.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/SelectCharacter.razor
@@ -1,0 +1,377 @@
+@page "/play"
+@page "/play/join/{PreselectedTableId:guid}"
+
+@rendermode InteractiveServer
+
+@attribute [Authorize]
+
+@using Threa.Services
+@using Threa.Client.Components.Shared
+
+@inject Csla.Blazor.State.StateManager StateManager
+@inject RenderModeProvider RenderModeProvider
+@inject NavigationManager NavigationManager
+@inject ApplicationContext applicationContext
+@inject IDataPortal<GameMechanics.Player.CharacterList> characterListPortal
+@inject IDataPortal<GameMechanics.GamePlay.TableList> tableListPortal
+@inject IDataPortal<GameMechanics.GamePlay.TableCharacterDetacher> detacherPortal
+@inject IDataPortal<GameMechanics.GamePlay.TableCharacterAttacher> attacherPortal
+
+<PageTitle>Threa - Select Character</PageTitle>
+
+@if (errorMessage != null)
+{
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <i class="bi bi-exclamation-triangle-fill me-2"></i>
+        <strong>Error:</strong> @errorMessage
+        <button type="button" class="btn-close" @onclick="() => errorMessage = null" aria-label="Close"></button>
+    </div>
+}
+
+<h3>Select a Character to Play</h3>
+
+@if (availableCharacters == null)
+{
+    <p>Loading characters...</p>
+}
+else if (!availableCharacters.Any())
+{
+    <div class="alert alert-info">
+        <p>You don't have any activated characters to play.</p>
+        <p><a href="/player/characters">Create and activate a character</a> to start playing.</p>
+    </div>
+}
+else
+{
+    <div class="list-group" style="max-width: 500px;">
+        @foreach (var charInfo in availableCharacters)
+        {
+            <div class="list-group-item d-flex justify-content-between align-items-center">
+                <div class="d-flex align-items-center gap-2 flex-grow-1"
+                     style="cursor: pointer;"
+                     @onclick="() => SelectCharacterAsync(charInfo)">
+                    <div>
+                        <strong>@charInfo.Name</strong>
+                        <br />
+                        <small class="text-muted">@charInfo.Species</small>
+                        @if (charInfo.IsAttachedToTable)
+                        {
+                            <br />
+                            <small class="text-info"><i class="bi bi-table"></i> Table: @charInfo.TableName</small>
+                        }
+                    </div>
+                </div>
+                <div class="d-flex gap-2">
+                    @if (charInfo.IsAttachedToTable)
+                    {
+                        <button class="btn btn-sm btn-outline-warning"
+                                title="Detach from table"
+                                @onclick="() => ShowDetachConfirmation(charInfo)"
+                                @onclick:stopPropagation="true">
+                            <i class="bi bi-box-arrow-right"></i>
+                        </button>
+                    }
+                    <button class="btn btn-sm btn-success"
+                            @onclick="() => SelectCharacterAsync(charInfo)"
+                            @onclick:stopPropagation="true">
+                        Play
+                    </button>
+                </div>
+            </div>
+        }
+    </div>
+}
+
+@* Detach Confirmation Dialog *@
+@if (showDetachConfirmation && characterToDetach != null)
+{
+    <div class="modal fade show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header bg-warning">
+                    <h5 class="modal-title">Confirm Detach from Table</h5>
+                    <button type="button" class="btn-close" @onclick="CancelDetach"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Are you sure you want to detach <strong>@characterToDetach.Name</strong> from table <strong>@characterToDetach.TableName</strong>?</p>
+                    <div class="alert alert-warning">
+                        <i class="bi bi-exclamation-triangle"></i>
+                        <strong>Warning:</strong> This will remove your character from the active game session.
+                        You will need to rejoin the table to continue playing in that session.
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="CancelDetach">Cancel</button>
+                    <button type="button" class="btn btn-warning" @onclick="ConfirmDetach" disabled="@isDetaching">
+                        @if (isDetaching)
+                        {
+                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                            <span>Detaching...</span>
+                        }
+                        else
+                        {
+                            <span>Detach Character</span>
+                        }
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@* Table Selection Dialog *@
+@if (showTableSelection && characterToAttach != null)
+{
+    <div class="modal fade show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header bg-primary text-white">
+                    <h5 class="modal-title">Join a Table</h5>
+                    <button type="button" class="btn-close btn-close-white" @onclick="CancelTableSelection"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Select a table for <strong>@characterToAttach.Name</strong> to join:</p>
+
+                    @if (availableTables == null)
+                    {
+                        <p>Loading tables...</p>
+                    }
+                    else if (!availableTables.Any())
+                    {
+                        <div class="alert alert-info">
+                            <p>No active tables available.</p>
+                            <p>You can still play without joining a table, or ask a Game Master to create one.</p>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="list-group mb-3">
+                            @foreach (var tableInfo in availableTables)
+                            {
+                                <button type="button"
+                                        class="list-group-item list-group-item-action d-flex justify-content-between align-items-center @(selectedTableId == tableInfo.Id ? "active" : "")"
+                                        @onclick="() => selectedTableId = tableInfo.Id">
+                                    <div>
+                                        <strong>@tableInfo.Name</strong>
+                                        <br />
+                                        <small>@tableInfo.StatusDisplay - Round @tableInfo.CurrentRound</small>
+                                    </div>
+                                    @if (selectedTableId == tableInfo.Id)
+                                    {
+                                        <i class="bi bi-check-circle-fill"></i>
+                                    }
+                                </button>
+                            }
+                        </div>
+                    }
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="CancelTableSelection">Cancel</button>
+                    <button type="button" class="btn btn-outline-primary" @onclick="PlayWithoutTable">
+                        Play Without Table
+                    </button>
+                    @if (availableTables != null && availableTables.Any())
+                    {
+                        <button type="button" class="btn btn-primary"
+                                @onclick="ConfirmTableSelection"
+                                disabled="@(selectedTableId == Guid.Empty || isAttaching)">
+                            @if (isAttaching)
+                            {
+                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                <span>Joining...</span>
+                            }
+                            else
+                            {
+                                <span>Join Table</span>
+                            }
+                        </button>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public Guid PreselectedTableId { get; set; }
+
+    private IEnumerable<GameMechanics.Player.CharacterInfo>? availableCharacters;
+    private IEnumerable<GameMechanics.GamePlay.TableInfo>? availableTables;
+    private string? errorMessage;
+    private int currentPlayerId;
+
+    // Detach confirmation state
+    private bool showDetachConfirmation;
+    private bool isDetaching;
+    private GameMechanics.Player.CharacterInfo? characterToDetach;
+
+    // Table selection state
+    private bool showTableSelection;
+    private bool isAttaching;
+    private GameMechanics.Player.CharacterInfo? characterToAttach;
+    private Guid selectedTableId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await StateManager.InitializeAsync();
+
+        if (RenderModeProvider.GetRenderMode(this).IsInteractive())
+        {
+            // Get the current player ID from claims
+            currentPlayerId = int.Parse(applicationContext.Principal.Claims
+                .Where(_ => _.Type == System.Security.Claims.ClaimTypes.NameIdentifier).First().Value);
+
+            await LoadCharactersAsync();
+        }
+    }
+
+    private async Task LoadCharactersAsync()
+    {
+        var charList = await characterListPortal.FetchAsync(currentPlayerId);
+        availableCharacters = charList.Where(c => c.IsPlayable);
+    }
+
+    private async Task LoadTablesAsync()
+    {
+        try
+        {
+            var tableList = await tableListPortal.FetchAsync();
+            availableTables = tableList.Where(t => t.Status != Threa.Dal.Dto.TableStatus.Ended);
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to load tables: {ex.Message}";
+        }
+    }
+
+    private async Task SelectCharacterAsync(GameMechanics.Player.CharacterInfo charInfo)
+    {
+        try
+        {
+            errorMessage = null;
+
+            if (charInfo.IsAttachedToTable && charInfo.TableId != null)
+            {
+                // Character is attached to a table - navigate directly to play page with table
+                NavigationManager.NavigateTo($"/play/{charInfo.Id}/{charInfo.TableId}");
+            }
+            else if (PreselectedTableId != Guid.Empty)
+            {
+                // We have a preselected table from the URL - show table selection with it pre-selected
+                characterToAttach = charInfo;
+                selectedTableId = PreselectedTableId;
+                await LoadTablesAsync();
+                showTableSelection = true;
+            }
+            else
+            {
+                // Character not attached to a table - show table selection dialog
+                characterToAttach = charInfo;
+                selectedTableId = Guid.Empty;
+                await LoadTablesAsync();
+                showTableSelection = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to select character: {ex.Message}";
+        }
+    }
+
+    // Detach confirmation methods
+    private void ShowDetachConfirmation(GameMechanics.Player.CharacterInfo charInfo)
+    {
+        characterToDetach = charInfo;
+        showDetachConfirmation = true;
+    }
+
+    private void CancelDetach()
+    {
+        showDetachConfirmation = false;
+        characterToDetach = null;
+    }
+
+    private async Task ConfirmDetach()
+    {
+        if (characterToDetach == null) return;
+
+        try
+        {
+            isDetaching = true;
+            errorMessage = null;
+
+            var result = await detacherPortal.ExecuteAsync(characterToDetach.Id);
+
+            if (result.Success)
+            {
+                // Reload the character list to reflect the change
+                await LoadCharactersAsync();
+            }
+            else
+            {
+                errorMessage = result.ErrorMessage ?? "Failed to detach character from table.";
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to detach character: {ex.Message}";
+        }
+        finally
+        {
+            isDetaching = false;
+            showDetachConfirmation = false;
+            characterToDetach = null;
+        }
+    }
+
+    // Table selection methods
+    private void CancelTableSelection()
+    {
+        showTableSelection = false;
+        characterToAttach = null;
+        selectedTableId = Guid.Empty;
+    }
+
+    private void PlayWithoutTable()
+    {
+        if (characterToAttach == null) return;
+
+        // Navigate to play page without table
+        NavigationManager.NavigateTo($"/play/{characterToAttach.Id}");
+    }
+
+    private async Task ConfirmTableSelection()
+    {
+        if (characterToAttach == null || selectedTableId == Guid.Empty) return;
+
+        try
+        {
+            isAttaching = true;
+            errorMessage = null;
+
+            var result = await attacherPortal.ExecuteAsync(characterToAttach.Id, selectedTableId, currentPlayerId);
+
+            if (result.Success)
+            {
+                // Navigate to play page with character and table
+                NavigationManager.NavigateTo($"/play/{characterToAttach.Id}/{selectedTableId}");
+            }
+            else
+            {
+                errorMessage = result.ErrorMessage ?? "Failed to join table.";
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Failed to join table: {ex.Message}";
+        }
+        finally
+        {
+            isAttaching = false;
+            showTableSelection = false;
+            characterToAttach = null;
+            selectedTableId = Guid.Empty;
+        }
+    }
+}

--- a/Threa/Threa.Client/Components/Pages/Player/MyJoinRequests.razor
+++ b/Threa/Threa.Client/Components/Pages/Player/MyJoinRequests.razor
@@ -81,7 +81,7 @@
                                     <span class="badge bg-success">
                                         <i class="bi bi-check-circle me-1"></i>Approved
                                     </span>
-                                    <a href="/play/@request.TableId" class="btn btn-sm btn-success">
+                                    <a href="/play/@request.CharacterId/@request.TableId" class="btn btn-sm btn-success">
                                         <i class="bi bi-play-fill me-1"></i>Go to Campaign
                                     </a>
                                 </div>


### PR DESCRIPTION
## Summary
- Creates new `SelectCharacter.razor` page at `/play` for character selection
- Updates `Play.razor` to require character ID in URL (`/play/{CharacterId:int}`)
- Adds `/play/join/{TableId}` route for GM-shared table join links
- Browser refresh now stays on the play page instead of returning to character selection

## Changes
- **SelectCharacter.razor**: New page handling character selection, table selection dialogs, and detach functionality
- **Play.razor**: Simplified to only handle playing a character (loaded from URL parameter)
- **MyJoinRequests.razor**: Updated link to use new URL format `/play/{CharacterId}/{TableId}`
- **GmTable.razor**: Updated player join link to use `/play/join/{TableId}`

## Test plan
- [ ] Navigate to `/play` - should show character selection
- [ ] Select a character attached to a table - should navigate to `/play/{charId}/{tableId}`
- [ ] Select a character not attached to a table - should show table selection dialog
- [ ] Join a table from the dialog - should navigate and attach character
- [ ] Play without table - should navigate to `/play/{charId}`
- [ ] Refresh browser on play page - should reload same character (not go back to selection)
- [ ] Use GM "Join Link" - should go to `/play/join/{tableId}` with table pre-selected

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)