### PR TITLE
Add weapon unload and reload time mechanics (#40, #41)

### DIFF
--- a/GameMechanics/Effects/Behaviors/MagazineReloadPayload.cs
+++ b/GameMechanics/Effects/Behaviors/MagazineReloadPayload.cs
@@ -29,6 +29,19 @@ public class MagazineReloadPayload
     public int RoundsToLoad { get; set; }
 
     /// <summary>
+    /// Whether the ammo source is loose ammo (stack) rather than a magazine (container).
+    /// When true, StackSize is reduced instead of AmmoContainerState.
+    /// </summary>
+    [JsonPropertyName("isLooseAmmo")]
+    public bool IsLooseAmmo { get; set; }
+
+    /// <summary>
+    /// The ammo type being loaded (e.g., "9mm").
+    /// </summary>
+    [JsonPropertyName("ammoType")]
+    public string? AmmoType { get; set; }
+
+    /// <summary>
     /// Serializes this payload to JSON for storage in ConcentrationState.
     /// </summary>
     public string Serialize()

--- a/GameMechanics/Effects/Behaviors/WeaponUnloadPayload.cs
+++ b/GameMechanics/Effects/Behaviors/WeaponUnloadPayload.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GameMechanics.Effects.Behaviors;
+
+/// <summary>
+/// Payload for weapon unload deferred action.
+/// Stores all data needed to complete unloading ammo from a weapon to inventory when concentration finishes.
+/// </summary>
+public class WeaponUnloadPayload
+{
+    /// <summary>
+    /// The weapon CharacterItem ID being unloaded.
+    /// </summary>
+    [JsonPropertyName("weaponItemId")]
+    public Guid WeaponItemId { get; set; }
+
+    /// <summary>
+    /// The character ID who owns the weapon.
+    /// </summary>
+    [JsonPropertyName("characterId")]
+    public int CharacterId { get; set; }
+
+    /// <summary>
+    /// Number of rounds to unload from the weapon.
+    /// </summary>
+    [JsonPropertyName("roundsToUnload")]
+    public int RoundsToUnload { get; set; }
+
+    /// <summary>
+    /// Type of ammo being unloaded (e.g., "9mm", "Arrow").
+    /// </summary>
+    [JsonPropertyName("ammoType")]
+    public string? AmmoType { get; set; }
+
+    /// <summary>
+    /// Display name of the weapon for messages.
+    /// </summary>
+    [JsonPropertyName("weaponName")]
+    public string? WeaponName { get; set; }
+
+    /// <summary>
+    /// Serializes this payload to JSON for storage in ConcentrationState.
+    /// </summary>
+    public string Serialize()
+    {
+        return JsonSerializer.Serialize(this, new JsonSerializerOptions
+        {
+            WriteIndented = false
+        });
+    }
+
+    /// <summary>
+    /// Deserializes a payload from JSON.
+    /// </summary>
+    public static WeaponUnloadPayload? FromJson(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<WeaponUnloadPayload>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/Threa/Threa.Client/Components/Pages/GamePlay/AmmoSourceInfo.cs
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/AmmoSourceInfo.cs
@@ -83,3 +83,34 @@ public class ReloadCompleteData
     /// </summary>
     public int AmmoSourceRemaining { get; set; }
 }
+
+/// <summary>
+/// Data returned when a weapon unload is completed.
+/// </summary>
+public class UnloadCompleteData
+{
+    /// <summary>
+    /// Message to log.
+    /// </summary>
+    public string Message { get; set; } = "";
+
+    /// <summary>
+    /// The weapon item that was unloaded.
+    /// </summary>
+    public Guid WeaponItemId { get; set; }
+
+    /// <summary>
+    /// Number of rounds unloaded.
+    /// </summary>
+    public int RoundsUnloaded { get; set; }
+
+    /// <summary>
+    /// Remaining ammo in the weapon after unload.
+    /// </summary>
+    public int RemainingAmmo { get; set; }
+
+    /// <summary>
+    /// Type of ammo that was unloaded.
+    /// </summary>
+    public string? AmmoType { get; set; }
+}

--- a/Threa/Threa.Client/Components/Pages/GamePlay/ReloadMode.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/ReloadMode.razor
@@ -4,6 +4,7 @@
 @using Threa.Dal.Dto
 
 @inject Radzen.DialogService DialogService
+@inject Csla.IChildDataPortal<GameMechanics.EffectRecord> EffectPortal
 
 <div class="reload-mode">
     <div class="d-flex justify-content-between align-items-center mb-3">
@@ -164,6 +165,26 @@
                                         <td>Cost:</td>
                                         <td>@GetCostDisplay()</td>
                                     </tr>
+                                    @if (RequiresConcentration())
+                                    {
+                                        <tr>
+                                            <td colspan="2"><hr class="my-1" /></td>
+                                        </tr>
+                                        <tr>
+                                            <td>Duration:</td>
+                                            <td class="fw-bold text-warning">
+                                                <i class="bi bi-hourglass-split"></i> @GetConcentrationDuration() round(s)
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="2">
+                                                <small class="text-muted">
+                                                    Reloading from loose ammo requires concentration.
+                                                    Action completes when GM advances time.
+                                                </small>
+                                            </td>
+                                        </tr>
+                                    }
                                 </tbody>
                             </table>
                         }
@@ -176,7 +197,14 @@
                         <button class="btn btn-success btn-lg w-100"
                                 @onclick="ExecuteReload"
                                 disabled="@(!CanReload())">
-                            <i class="bi bi-box-arrow-in-down"></i> Reload
+                            @if (RequiresConcentration())
+                            {
+                                <i class="bi bi-hourglass-split"></i> <text>Begin Reloading</text>
+                            }
+                            else
+                            {
+                                <i class="bi bi-box-arrow-in-down"></i> <text>Reload</text>
+                            }
                         </button>
                     </div>
                 </div>
@@ -209,9 +237,46 @@
             </div>
         </div>
     }
+    else if (concentrationReloadPending)
+    {
+        <!-- Concentration Reload Started -->
+        <div class="card">
+            <div class="card-header bg-warning text-dark">
+                <strong><i class="bi bi-hourglass-split"></i> Reloading in Progress...</strong>
+            </div>
+            <div class="card-body">
+                <table class="table table-sm">
+                    <tbody>
+                        <tr>
+                            <td>Weapon:</td>
+                            <td class="fw-bold">@reloadResult?.WeaponName</td>
+                        </tr>
+                        <tr>
+                            <td>Rounds Loading:</td>
+                            <td class="fw-bold text-warning">@reloadResult?.RoundsLoaded</td>
+                        </tr>
+                        <tr>
+                            <td>From:</td>
+                            <td class="fw-bold">@reloadResult?.AmmoSourceName</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <div class="alert alert-info mb-0 mt-3">
+                    <i class="bi bi-info-circle"></i>
+                    <strong>Concentrating</strong> - Reload will complete when GM advances time.
+                    Taking any action will interrupt the reload.
+                </div>
+            </div>
+            <div class="card-footer">
+                <button class="btn btn-primary" @onclick="CompleteConcentrationReload">
+                    <i class="bi bi-check"></i> Done
+                </button>
+            </div>
+        </div>
+    }
     else
     {
-        <!-- Reload Result -->
+        <!-- Immediate Reload Result -->
         <div class="card">
             <div class="card-header bg-success text-white">
                 <strong><i class="bi bi-check-circle"></i> Weapon Reloaded!</strong>
@@ -280,6 +345,7 @@
 
     // Result state
     private bool hasReloaded;
+    private bool concentrationReloadPending;
     private ReloadResultData? reloadResult;
 
     private void SelectWeapon(RangedWeaponInfo weapon)
@@ -355,9 +421,38 @@
         var apNeeded = costType == ActionCostType.TwoAP ? 2 : 1;
         var fatNeeded = costType == ActionCostType.OneAPOneFat ? 1 : 0;
 
+        // Can't start concentration if already concentrating (unless user confirms break)
+        // But we check this in ExecuteReload, not here
+
         return Character.ActionPoints.Available >= apNeeded &&
                Character.Fatigue.Value >= fatNeeded &&
                !Character.IsPassedOut;
+    }
+
+    /// <summary>
+    /// Checks if this reload requires concentration (takes multiple rounds).
+    /// Loose ammo reloads with more than 1 round require concentration.
+    /// </summary>
+    private bool RequiresConcentration()
+    {
+        if (selectedMagazine == null) return false;
+
+        // Magazine swaps are instant
+        if (!selectedMagazine.IsLooseAmmo) return false;
+
+        // Loose ammo: 1 round is instant, more requires concentration
+        int roundsToLoad = GetRoundsToLoad();
+        return roundsToLoad > 1;
+    }
+
+    /// <summary>
+    /// Gets the number of concentration rounds required.
+    /// Rate: 3 rounds per game round (1 round per second).
+    /// </summary>
+    private int GetConcentrationDuration()
+    {
+        int roundsToLoad = GetRoundsToLoad();
+        return (int)Math.Ceiling(roundsToLoad / 3.0);
     }
 
     private async Task ExecuteReload()
@@ -395,16 +490,56 @@
         // Calculate reload amounts
         int roundsToLoad = GetRoundsToLoad();
 
-        // Store result
-        reloadResult = new ReloadResultData
+        // Check if this reload requires concentration
+        if (RequiresConcentration())
         {
-            WeaponName = selectedWeapon.Name,
-            RoundsLoaded = roundsToLoad,
-            NewAmmoCount = selectedWeapon.LoadedAmmo + roundsToLoad,
-            Capacity = selectedWeapon.Capacity,
-            AmmoSourceName = selectedMagazine.Name,
-            AmmoSourceRemaining = selectedMagazine.CurrentAmmo - roundsToLoad
-        };
+            // Create concentration effect for multi-round reload from loose ammo
+            var behaviorState = ConcentrationBehavior.CreateWeaponReloadState(
+                selectedWeapon.ItemId,
+                selectedMagazine.ItemId,
+                roundsToLoad,
+                isLooseAmmo: true,
+                ammoType: selectedMagazine.AmmoType,
+                weaponName: selectedWeapon.Name);
+
+            // Create concentration effect using the portal
+            var effect = EffectPortal.CreateChild(
+                EffectType.Concentration,
+                $"Reloading {selectedWeapon.Name}",
+                null,  // location - not applicable for concentration
+                (int?)null,  // durationRounds - concentration tracks its own progress
+                behaviorState);
+            effect.Description = $"Loading {roundsToLoad} rounds ({GetConcentrationDuration()} round(s) remaining)";
+            effect.Source = "Combat";
+
+            Character.Effects.AddEffect(effect);
+
+            // Store result for concentration display
+            concentrationReloadPending = true;
+            reloadResult = new ReloadResultData
+            {
+                WeaponName = selectedWeapon.Name,
+                RoundsLoaded = roundsToLoad,
+                NewAmmoCount = selectedWeapon.LoadedAmmo + roundsToLoad,
+                Capacity = selectedWeapon.Capacity,
+                AmmoSourceName = selectedMagazine.Name,
+                AmmoSourceRemaining = selectedMagazine.CurrentAmmo - roundsToLoad
+            };
+        }
+        else
+        {
+            // Immediate reload (magazine swap or single round from loose ammo)
+            concentrationReloadPending = false;
+            reloadResult = new ReloadResultData
+            {
+                WeaponName = selectedWeapon.Name,
+                RoundsLoaded = roundsToLoad,
+                NewAmmoCount = selectedWeapon.LoadedAmmo + roundsToLoad,
+                Capacity = selectedWeapon.Capacity,
+                AmmoSourceName = selectedMagazine.Name,
+                AmmoSourceRemaining = selectedMagazine.CurrentAmmo - roundsToLoad
+            };
+        }
 
         hasReloaded = true;
 
@@ -418,6 +553,7 @@
     private void ResetReload()
     {
         hasReloaded = false;
+        concentrationReloadPending = false;
         reloadResult = null;
         selectedWeapon = null;
         selectedMagazine = null;
@@ -437,6 +573,31 @@
             RoundsLoaded = reloadResult.RoundsLoaded,
             NewWeaponAmmoCount = reloadResult.NewAmmoCount,
             AmmoSourceRemaining = reloadResult.AmmoSourceRemaining
+        };
+
+        await OnReloadComplete.InvokeAsync(completeData);
+    }
+
+    /// <summary>
+    /// Completes a concentration-based reload. Item updates will happen when
+    /// the concentration effect completes (GM advances time).
+    /// </summary>
+    private async Task CompleteConcentrationReload()
+    {
+        if (reloadResult == null || selectedWeapon == null || selectedMagazine == null) return;
+
+        var message = $"{Character?.Name} begins reloading {reloadResult.WeaponName} with {reloadResult.RoundsLoaded} rounds from {reloadResult.AmmoSourceName}";
+
+        // For concentration reloads, we don't update items immediately.
+        // Just log the action start and return to default mode.
+        var completeData = new ReloadCompleteData
+        {
+            Message = message,
+            WeaponItemId = Guid.Empty, // Don't update weapon yet
+            AmmoSourceItemId = Guid.Empty, // Don't update ammo source yet
+            RoundsLoaded = 0, // No immediate change
+            NewWeaponAmmoCount = selectedWeapon.LoadedAmmo, // Current (unchanged)
+            AmmoSourceRemaining = selectedMagazine.CurrentAmmo // Current (unchanged)
         };
 
         await OnReloadComplete.InvokeAsync(completeData);

--- a/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
@@ -8,6 +8,7 @@
 @using Threa.Client.Components.Shared
 
 @inject ICharacterItemDal CharacterItemDal
+@inject IItemTemplateDal ItemTemplateDal
 @inject IActivityLogService ActivityLog
 
 <div class="combat-tab-container">
@@ -94,6 +95,18 @@
                             <i class="bi bi-box-arrow-in-down fs-4"></i>
                             <div class="fw-bold">RELOAD</div>
                             <small class="opacity-75">1 AP + 1 FAT or 2 AP</small>
+                        </button>
+                    }
+
+                    <!-- Unload Button -->
+                    @if (HasWeaponWithAmmo())
+                    {
+                        <button class="btn btn-lg btn-outline-warning py-3"
+                                @onclick="StartUnload"
+                                disabled="@(!CanAct())">
+                            <i class="bi bi-box-arrow-up fs-4"></i>
+                            <div class="fw-bold">UNLOAD</div>
+                            <small class="opacity-75">Remove ammo from weapon</small>
                         </button>
                     }
 
@@ -235,6 +248,14 @@
                     OnCancel="ReturnToDefault"
                     OnReloadComplete="OnReloadComplete" />
     }
+    else if (combatMode == CombatMode.Unload)
+    {
+        <UnloadMode Character="Character"
+                    Table="Table"
+                    AvailableWeapons="rangedWeapons"
+                    OnCancel="ReturnToDefault"
+                    OnUnloadComplete="OnUnloadComplete" />
+    }
     else if (combatMode == CombatMode.Medical)
     {
         <MedicalMode Character="Character"
@@ -255,7 +276,7 @@
     [Parameter]
     public EventCallback OnCharacterChanged { get; set; }
 
-    private enum CombatMode { Default, Attack, Defend, TakeDamage, RangedAttack, Reload, Medical }
+    private enum CombatMode { Default, Attack, Defend, TakeDamage, RangedAttack, Reload, Unload, Medical }
     private CombatMode combatMode = CombatMode.Default;
 
     private List<GameMechanics.SkillEdit> filteredSkills = new();
@@ -599,6 +620,21 @@
         combatMode = CombatMode.Medical;
     }
 
+    private void StartUnload()
+    {
+        // Unloading ends parry mode
+        if (Character != null && CombatStanceBehavior.IsInParryMode(Character))
+        {
+            CombatStanceBehavior.EndParryMode(Character);
+        }
+        combatMode = CombatMode.Unload;
+    }
+
+    private bool HasWeaponWithAmmo()
+    {
+        return rangedWeapons.Any(w => w.LoadedAmmo > 0);
+    }
+
     private async Task LoadAvailableAmmoSources()
     {
         availableAmmoSources = new List<AmmoSourceInfo>();
@@ -821,6 +857,101 @@
 
         combatMode = CombatMode.Default;
         await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnUnloadComplete(UnloadCompleteData data)
+    {
+        LogActivity(data.Message, ActivityCategory.Combat);
+
+        // Update the weapon's ammo state (for immediate unloads, not concentration)
+        if (data.WeaponItemId != Guid.Empty && data.RoundsUnloaded > 0)
+        {
+            var weapon = rangedWeapons.FirstOrDefault(w => w.ItemId == data.WeaponItemId);
+            if (weapon != null)
+            {
+                weapon.LoadedAmmo = data.RemainingAmmo;
+
+                // Update the weapon item in the database
+                var weaponItem = equippedItems.FirstOrDefault(i => i.Id == data.WeaponItemId);
+                if (weaponItem != null)
+                {
+                    var ammoState = WeaponAmmoState.FromJson(weaponItem.CustomProperties);
+                    ammoState.LoadedAmmo = data.RemainingAmmo;
+                    weaponItem.CustomProperties = WeaponAmmoState.MergeIntoCustomProperties(weaponItem.CustomProperties, ammoState);
+                    await CharacterItemDal.UpdateItemAsync(weaponItem);
+                }
+
+                // For immediate unloads, create loose ammo in inventory
+                // (For concentration unloads, this is handled by TimeAdvancementService)
+                await CreateLooseAmmoFromUnload(data);
+            }
+        }
+
+        combatMode = CombatMode.Default;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task CreateLooseAmmoFromUnload(UnloadCompleteData data)
+    {
+        if (Character == null || data.RoundsUnloaded <= 0 || string.IsNullOrEmpty(data.AmmoType)) return;
+
+        // Get all character's items to find a matching loose ammo stack
+        var allItems = await CharacterItemDal.GetCharacterItemsAsync(Character.Id);
+
+        // Find existing loose ammo of the same type
+        CharacterItem? existingLooseAmmo = null;
+        foreach (var item in allItems)
+        {
+            if (item.ContainerItemId != null) continue;
+            if (item.Template?.ItemType != ItemType.Ammunition) continue;
+
+            var ammoProps = AmmunitionProperties.FromJson(item.Template.CustomProperties);
+            if (ammoProps == null || ammoProps.IsContainer) continue;
+
+            if (string.Equals(ammoProps.AmmoType, data.AmmoType, StringComparison.OrdinalIgnoreCase))
+            {
+                existingLooseAmmo = item;
+                break;
+            }
+        }
+
+        if (existingLooseAmmo != null)
+        {
+            // Add to existing stack
+            existingLooseAmmo.StackSize += data.RoundsUnloaded;
+            await CharacterItemDal.UpdateItemAsync(existingLooseAmmo);
+        }
+        else
+        {
+            // Need to create a new loose ammo item - find the template
+            var ammoTemplates = await ItemTemplateDal.GetTemplatesByTypeAsync(ItemType.Ammunition);
+            ItemTemplate? matchingTemplate = null;
+
+            foreach (var template in ammoTemplates)
+            {
+                var ammoProps = AmmunitionProperties.FromJson(template.CustomProperties);
+                if (ammoProps == null || ammoProps.IsContainer) continue;
+
+                if (string.Equals(ammoProps.AmmoType, data.AmmoType, StringComparison.OrdinalIgnoreCase))
+                {
+                    matchingTemplate = template;
+                    break;
+                }
+            }
+
+            if (matchingTemplate != null)
+            {
+                var newAmmo = new CharacterItem
+                {
+                    Id = Guid.NewGuid(),
+                    ItemTemplateId = matchingTemplate.Id,
+                    OwnerCharacterId = Character.Id,
+                    StackSize = data.RoundsUnloaded,
+                    CreatedAt = DateTime.UtcNow
+                };
+                await CharacterItemDal.AddItemAsync(newAmmo);
+            }
+        }
     }
 
     private async Task OnMedicalComplete(MedicalCompleteData data)

--- a/Threa/Threa.Client/Components/Pages/GamePlay/UnloadMode.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/UnloadMode.razor
@@ -1,0 +1,542 @@
+@using Threa.Client.Components.Shared
+@using GameMechanics.Combat
+@using GameMechanics.Effects.Behaviors
+@using Threa.Dal.Dto
+
+@inject Radzen.DialogService DialogService
+@inject Csla.IChildDataPortal<GameMechanics.EffectRecord> EffectPortal
+
+<div class="unload-mode">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0"><i class="bi bi-box-arrow-up text-warning"></i> Unload Weapon</h4>
+        <button class="btn btn-outline-secondary btn-sm" @onclick="OnCancel">
+            <i class="bi bi-x-lg"></i> Cancel
+        </button>
+    </div>
+
+    @if (!hasUnloaded)
+    {
+        <!-- Unload Setup -->
+        <div class="row">
+            <div class="col-md-6">
+                <!-- Weapon Selection -->
+                <div class="card mb-3">
+                    <div class="card-header">
+                        <strong>1. Select Weapon to Unload</strong>
+                    </div>
+                    <div class="card-body">
+                        @if (weaponsWithAmmo == null || !weaponsWithAmmo.Any())
+                        {
+                            <p class="text-muted">No weapons with loaded ammo.</p>
+                        }
+                        else
+                        {
+                            <div class="list-group">
+                                @foreach (var weapon in weaponsWithAmmo)
+                                {
+                                    <button class="list-group-item list-group-item-action @(selectedWeapon?.ItemId == weapon.ItemId ? "active" : "")"
+                                            @onclick="() => SelectWeapon(weapon)">
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <div>
+                                                <strong>@weapon.Name</strong>
+                                                <div class="small @(selectedWeapon?.ItemId == weapon.ItemId ? "" : "text-muted")">
+                                                    @weapon.LoadedAmmoType ammo
+                                                </div>
+                                            </div>
+                                            <div class="text-end">
+                                                <span class="badge bg-success">
+                                                    @weapon.LoadedAmmo rounds
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </button>
+                                }
+                            </div>
+                        }
+                    </div>
+                </div>
+
+                @if (selectedWeapon != null)
+                {
+                    <!-- Rounds to Unload -->
+                    <div class="card mb-3">
+                        <div class="card-header">
+                            <strong>2. Rounds to Unload</strong>
+                        </div>
+                        <div class="card-body">
+                            <div class="btn-group w-100" role="group">
+                                <button class="btn @(unloadAll ? "btn-warning" : "btn-outline-warning")"
+                                        @onclick="() => SetUnloadAll(true)">
+                                    All (@selectedWeapon.LoadedAmmo)
+                                </button>
+                                <button class="btn @(!unloadAll ? "btn-warning" : "btn-outline-warning")"
+                                        @onclick="() => SetUnloadAll(false)">
+                                    Partial
+                                </button>
+                            </div>
+                            @if (!unloadAll)
+                            {
+                                <div class="mt-3">
+                                    <label class="form-label">Rounds: @roundsToUnload</label>
+                                    <input type="range" class="form-range" min="1" max="@selectedWeapon.LoadedAmmo"
+                                           @bind="roundsToUnload" @bind:event="oninput" />
+                                </div>
+                            }
+                        </div>
+                    </div>
+
+                    <!-- Action Cost -->
+                    <div class="card mb-3">
+                        <div class="card-header">
+                            <strong>3. Action Cost</strong>
+                        </div>
+                        <div class="card-body">
+                            <ActionCostSelector AP="@(Character?.ActionPoints.Available ?? 0)"
+                                                Fat="@(Character?.Fatigue.Value ?? 0)"
+                                                OnCostTypeSelected="OnCostTypeChanged" />
+                        </div>
+                    </div>
+                }
+            </div>
+
+            <div class="col-md-6">
+                <!-- Unload Summary -->
+                <div class="card">
+                    <div class="card-header bg-warning text-dark">
+                        <strong><i class="bi bi-info-circle"></i> Unload Summary</strong>
+                    </div>
+                    <div class="card-body">
+                        @if (selectedWeapon != null)
+                        {
+                            <table class="table table-sm mb-0">
+                                <tbody>
+                                    <tr>
+                                        <td>Weapon:</td>
+                                        <td class="fw-bold">@selectedWeapon.Name</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Current Ammo:</td>
+                                        <td class="fw-bold">@selectedWeapon.LoadedAmmo rounds</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Ammo Type:</td>
+                                        <td class="fw-bold">@selectedWeapon.LoadedAmmoType</td>
+                                    </tr>
+                                    <tr>
+                                        <td colspan="2"><hr class="my-1" /></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Rounds to Unload:</td>
+                                        <td class="fw-bold text-warning">@GetRoundsToUnload()</td>
+                                    </tr>
+                                    <tr>
+                                        <td>After Unload:</td>
+                                        <td class="fw-bold">@GetAmmoAfterUnload() rounds</td>
+                                    </tr>
+                                    <tr>
+                                        <td colspan="2"><hr class="my-1" /></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Cost:</td>
+                                        <td>@GetCostDisplay()</td>
+                                    </tr>
+                                    @if (RequiresConcentration())
+                                    {
+                                        <tr>
+                                            <td colspan="2"><hr class="my-1" /></td>
+                                        </tr>
+                                        <tr>
+                                            <td>Duration:</td>
+                                            <td class="fw-bold text-warning">
+                                                <i class="bi bi-hourglass-split"></i> @GetConcentrationDuration() round(s)
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td colspan="2">
+                                                <small class="text-muted">
+                                                    Unloading multiple rounds requires concentration.
+                                                    Action completes when GM advances time.
+                                                </small>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        }
+                        else
+                        {
+                            <p class="text-muted mb-0">Select a weapon to see unload details.</p>
+                        }
+                    </div>
+                    <div class="card-footer">
+                        <button class="btn btn-warning btn-lg w-100"
+                                @onclick="ExecuteUnload"
+                                disabled="@(!CanUnload())">
+                            @if (RequiresConcentration())
+                            {
+                                <i class="bi bi-hourglass-split"></i> <text>Begin Unloading</text>
+                            }
+                            else
+                            {
+                                <i class="bi bi-box-arrow-up"></i> <text>Unload</text>
+                            }
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Current Equipment Status -->
+                <div class="card mt-3">
+                    <div class="card-body py-2">
+                        <div class="row text-center">
+                            <div class="col-4">
+                                <small class="text-muted">AP</small>
+                                <div class="fw-bold @(Character?.ActionPoints.Available <= 0 ? "text-danger" : "")">
+                                    @Character?.ActionPoints.Available / @Character?.ActionPoints.Max
+                                </div>
+                            </div>
+                            <div class="col-4">
+                                <small class="text-muted">FAT</small>
+                                <div class="fw-bold @(Character?.Fatigue.Value <= 0 ? "text-danger" : "")">
+                                    @Character?.Fatigue.Value / @Character?.Fatigue.BaseValue
+                                </div>
+                            </div>
+                            <div class="col-4">
+                                <small class="text-muted">VIT</small>
+                                <div class="fw-bold">
+                                    @Character?.Vitality.Value / @Character?.Vitality.BaseValue
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+    else if (concentrationUnloadPending)
+    {
+        <!-- Concentration Unload Started -->
+        <div class="card">
+            <div class="card-header bg-warning text-dark">
+                <strong><i class="bi bi-hourglass-split"></i> Unloading in Progress...</strong>
+            </div>
+            <div class="card-body">
+                <table class="table table-sm">
+                    <tbody>
+                        <tr>
+                            <td>Weapon:</td>
+                            <td class="fw-bold">@unloadResult?.WeaponName</td>
+                        </tr>
+                        <tr>
+                            <td>Rounds Unloading:</td>
+                            <td class="fw-bold text-warning">@unloadResult?.RoundsUnloaded</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <div class="alert alert-info mb-0 mt-3">
+                    <i class="bi bi-info-circle"></i>
+                    <strong>Concentrating</strong> - Unload will complete when GM advances time.
+                    Taking any action will interrupt the unload.
+                </div>
+            </div>
+            <div class="card-footer">
+                <button class="btn btn-primary" @onclick="CompleteConcentrationUnload">
+                    <i class="bi bi-check"></i> Done
+                </button>
+            </div>
+        </div>
+    }
+    else
+    {
+        <!-- Immediate Unload Result -->
+        <div class="card">
+            <div class="card-header bg-success text-white">
+                <strong><i class="bi bi-check-circle"></i> Weapon Unloaded!</strong>
+            </div>
+            <div class="card-body">
+                <table class="table table-sm">
+                    <tbody>
+                        <tr>
+                            <td>Weapon:</td>
+                            <td class="fw-bold">@unloadResult?.WeaponName</td>
+                        </tr>
+                        <tr>
+                            <td>Rounds Unloaded:</td>
+                            <td class="fw-bold text-success">@unloadResult?.RoundsUnloaded</td>
+                        </tr>
+                        <tr>
+                            <td>Remaining in Weapon:</td>
+                            <td class="fw-bold">@unloadResult?.RemainingAmmo</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="card-footer d-flex gap-2">
+                <button class="btn btn-primary" @onclick="CompleteUnload">
+                    <i class="bi bi-check"></i> Done
+                </button>
+                <button class="btn btn-outline-secondary" @onclick="ResetUnload">
+                    <i class="bi bi-arrow-repeat"></i> Unload Another
+                </button>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public GameMechanics.CharacterEdit? Character { get; set; }
+
+    [Parameter]
+    public GameMechanics.GamePlay.TableEdit? Table { get; set; }
+
+    [Parameter]
+    public List<RangedWeaponInfo>? AvailableWeapons { get; set; }
+
+    [Parameter]
+    public EventCallback OnCancel { get; set; }
+
+    [Parameter]
+    public EventCallback<UnloadCompleteData> OnUnloadComplete { get; set; }
+
+    // Selection state
+    private RangedWeaponInfo? selectedWeapon;
+    private bool unloadAll = true;
+    private int roundsToUnload = 1;
+    private ActionCostType costType = ActionCostType.OneAPOneFat;
+
+    // Result state
+    private bool hasUnloaded;
+    private bool concentrationUnloadPending;
+    private UnloadResultData? unloadResult;
+
+    // Computed: weapons that have ammo loaded
+    private IEnumerable<RangedWeaponInfo>? weaponsWithAmmo =>
+        AvailableWeapons?.Where(w => w.LoadedAmmo > 0);
+
+    private void SelectWeapon(RangedWeaponInfo weapon)
+    {
+        selectedWeapon = weapon;
+        roundsToUnload = weapon.LoadedAmmo; // Default to all
+        unloadAll = true;
+    }
+
+    private void SetUnloadAll(bool all)
+    {
+        unloadAll = all;
+        if (all && selectedWeapon != null)
+        {
+            roundsToUnload = selectedWeapon.LoadedAmmo;
+        }
+        else if (selectedWeapon != null)
+        {
+            roundsToUnload = Math.Min(roundsToUnload, selectedWeapon.LoadedAmmo);
+            if (roundsToUnload < 1) roundsToUnload = 1;
+        }
+    }
+
+    private void OnCostTypeChanged(ActionCostType type)
+    {
+        costType = type;
+    }
+
+    private int GetRoundsToUnload()
+    {
+        if (selectedWeapon == null) return 0;
+        return unloadAll ? selectedWeapon.LoadedAmmo : roundsToUnload;
+    }
+
+    private int GetAmmoAfterUnload()
+    {
+        if (selectedWeapon == null) return 0;
+        return selectedWeapon.LoadedAmmo - GetRoundsToUnload();
+    }
+
+    private string GetCostDisplay()
+    {
+        return costType switch
+        {
+            ActionCostType.OneAPOneFat => "1 AP + 1 FAT",
+            ActionCostType.TwoAP => "2 AP",
+            _ => "Unknown"
+        };
+    }
+
+    private bool CanUnload()
+    {
+        if (Character == null || selectedWeapon == null) return false;
+        if (GetRoundsToUnload() <= 0) return false;
+
+        var apNeeded = costType == ActionCostType.TwoAP ? 2 : 1;
+        var fatNeeded = costType == ActionCostType.OneAPOneFat ? 1 : 0;
+
+        return Character.ActionPoints.Available >= apNeeded &&
+               Character.Fatigue.Value >= fatNeeded &&
+               !Character.IsPassedOut;
+    }
+
+    /// <summary>
+    /// Checks if this unload requires concentration (takes multiple rounds).
+    /// Unloads with more than 1 round require concentration.
+    /// </summary>
+    private bool RequiresConcentration()
+    {
+        return GetRoundsToUnload() > 1;
+    }
+
+    /// <summary>
+    /// Gets the number of concentration rounds required.
+    /// Rate: 3 rounds per game round (1 round per second).
+    /// </summary>
+    private int GetConcentrationDuration()
+    {
+        int rounds = GetRoundsToUnload();
+        return (int)Math.Ceiling(rounds / 3.0);
+    }
+
+    private async Task ExecuteUnload()
+    {
+        if (!CanUnload() || Character == null || selectedWeapon == null) return;
+
+        // Check if character is concentrating - prompt before breaking
+        var concentrationEffect = Character.GetConcentrationEffect();
+        if (concentrationEffect != null)
+        {
+            var state = ConcentrationState.FromJson(concentrationEffect.BehaviorState);
+            if (state != null)
+            {
+                var confirmed = await ConcentrationBreakDialog.ShowAsync(
+                    DialogService,
+                    state,
+                    concentrationEffect.Name);
+                if (!confirmed)
+                    return; // User cancelled - don't execute action
+
+                // User confirmed - break concentration before proceeding
+                ConcentrationBehavior.BreakConcentration(Character, "Took unload action");
+            }
+        }
+
+        // Deduct costs
+        var apCost = costType == ActionCostType.TwoAP ? 2 : 1;
+        var fatCost = costType == ActionCostType.OneAPOneFat ? 1 : 0;
+
+        Character.ActionPoints.Available -= apCost;
+        Character.ActionPoints.ActionsTakenThisRound += 1;
+        if (fatCost > 0)
+            Character.Fatigue.Value -= fatCost;
+
+        // Calculate unload amounts
+        int rounds = GetRoundsToUnload();
+
+        // Check if this unload requires concentration
+        if (RequiresConcentration())
+        {
+            // Create concentration effect for multi-round unload
+            var behaviorState = ConcentrationBehavior.CreateWeaponUnloadState(
+                selectedWeapon.ItemId,
+                Character.Id,
+                rounds,
+                selectedWeapon.Name,
+                ammoType: selectedWeapon.LoadedAmmoType);
+
+            // Create concentration effect using the portal
+            var effect = EffectPortal.CreateChild(
+                EffectType.Concentration,
+                $"Unloading {selectedWeapon.Name}",
+                null,  // location - not applicable for concentration
+                (int?)null,  // durationRounds - concentration tracks its own progress
+                behaviorState);
+            effect.Description = $"Unloading {rounds} rounds ({GetConcentrationDuration()} round(s) remaining)";
+            effect.Source = "Combat";
+
+            Character.Effects.AddEffect(effect);
+
+            // Store result for concentration display
+            concentrationUnloadPending = true;
+            unloadResult = new UnloadResultData
+            {
+                WeaponName = selectedWeapon.Name,
+                RoundsUnloaded = rounds,
+                RemainingAmmo = selectedWeapon.LoadedAmmo - rounds
+            };
+        }
+        else
+        {
+            // Immediate unload (single round)
+            concentrationUnloadPending = false;
+            unloadResult = new UnloadResultData
+            {
+                WeaponName = selectedWeapon.Name,
+                RoundsUnloaded = rounds,
+                RemainingAmmo = selectedWeapon.LoadedAmmo - rounds
+            };
+        }
+
+        hasUnloaded = true;
+
+        // Save character state
+        if (Character is Csla.Core.ISavable savable)
+        {
+            await savable.SaveAsync();
+        }
+    }
+
+    private void ResetUnload()
+    {
+        hasUnloaded = false;
+        concentrationUnloadPending = false;
+        unloadResult = null;
+        selectedWeapon = null;
+        unloadAll = true;
+        roundsToUnload = 1;
+    }
+
+    private async Task CompleteUnload()
+    {
+        if (unloadResult == null || selectedWeapon == null) return;
+
+        var message = $"{Character?.Name} unloads {unloadResult.RoundsUnloaded} rounds from {unloadResult.WeaponName}";
+
+        var completeData = new UnloadCompleteData
+        {
+            Message = message,
+            WeaponItemId = selectedWeapon.ItemId,
+            RoundsUnloaded = unloadResult.RoundsUnloaded,
+            RemainingAmmo = unloadResult.RemainingAmmo,
+            AmmoType = selectedWeapon.LoadedAmmoType
+        };
+
+        await OnUnloadComplete.InvokeAsync(completeData);
+    }
+
+    /// <summary>
+    /// Completes a concentration-based unload. Item updates will happen when
+    /// the concentration effect completes (GM advances time).
+    /// </summary>
+    private async Task CompleteConcentrationUnload()
+    {
+        if (unloadResult == null || selectedWeapon == null) return;
+
+        var message = $"{Character?.Name} begins unloading {unloadResult.RoundsUnloaded} rounds from {unloadResult.WeaponName}";
+
+        // For concentration unloads, we don't update items immediately.
+        // Just log the action start and return to default mode.
+        var completeData = new UnloadCompleteData
+        {
+            Message = message,
+            WeaponItemId = Guid.Empty, // Don't update weapon yet
+            RoundsUnloaded = 0, // No immediate change
+            RemainingAmmo = selectedWeapon.LoadedAmmo, // Current (unchanged)
+            AmmoType = selectedWeapon.LoadedAmmoType
+        };
+
+        await OnUnloadComplete.InvokeAsync(completeData);
+    }
+
+    private class UnloadResultData
+    {
+        public string WeaponName { get; set; } = "";
+        public int RoundsUnloaded { get; set; }
+        public int RemainingAmmo { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

- **Issue #40**: Add ability to unload weapons in combat, removing ammo or ammo containers from the weapon
- **Issue #41**: Make reloading from loose ammo take time (concentration effect) when loading more than 1 round

## Changes

### Issue #40 - Weapon Unload in Combat
- Add `UnloadMode.razor` component with full UI for weapon unloading
- Add `WeaponUnloadPayload.cs` for storing unload action data
- Add `CreateWeaponUnloadState()` factory method to ConcentrationBehavior
- Add `ExecuteWeaponUnloadAsync()` to TimeAdvancementService
- Add Unload button, mode, and handlers in TabCombat.razor
- Supports both immediate (1 round) and concentration-based (multiple rounds) unloading
- Unloaded ammo is returned to inventory as loose ammo

### Issue #41 - Reload Takes Time
- Extend `MagazineReloadPayload` with `IsLooseAmmo` and `AmmoType` properties
- Update `ExecuteMagazineReloadAsync()` to handle loose ammo sources
- Add `CreateWeaponReloadState()` factory method for reload concentration
- Modify `ReloadMode.razor` to show concentration duration for loose ammo reloads
- Reloading 1 round from loose ammo is immediate
- Reloading 2+ rounds from loose ammo creates concentration effect
- Magazine swaps remain instant (they're a full swap operation)
- Rate: 3 rounds per game round (1 round per second)

## Test plan
- [x] All 995 existing tests pass
- [ ] Test immediate reload from loose ammo (1 round)
- [ ] Test concentration reload from loose ammo (2+ rounds) 
- [ ] Test magazine swap (should be instant)
- [ ] Test unloading 1 round from weapon (immediate)
- [ ] Test unloading multiple rounds from weapon (concentration)
- [ ] Verify unloaded ammo appears in inventory as loose ammo
- [ ] Verify concentration can be interrupted

Closes #40, closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)