### PR TITLE
Show detailed skill check calculation in result display

### DIFF
--- a/Threa/Threa.Client/Components/Pages/GamePlay/TabPlaySkills.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/TabPlaySkills.razor
@@ -146,12 +146,51 @@
                     <strong>Result: @(lastCheckResult.Success ? "Success" : "Failure")</strong>
                 </div>
                 <div class="card-body">
-                    <p>AS: @lastCheckResult.AbilityScore vs TV: @lastCheckResult.TargetValue</p>
-                    <p>Success Value: <strong>@lastCheckResult.SuccessValue</strong></p>
-                    <p class="text-muted small">@lastCheckResult.Outcome</p>
+                    <h6 class="mb-2">@lastCheckResult.Outcome</h6>
+
+                    <div class="mb-3">
+                        <table class="table table-sm table-borderless mb-0">
+                            <tbody>
+                                <tr>
+                                    <td class="text-muted">4dF+ Roll:</td>
+                                    <td class="text-end"><strong>@FormatRoll(lastCheckResult.Roll)</strong></td>
+                                </tr>
+                                <tr>
+                                    <td class="text-muted">Base AS:</td>
+                                    <td class="text-end">@lastCheckResult.BaseAbilityScore</td>
+                                </tr>
+                                @if (lastCheckResult.BoostValue != 0)
+                                {
+                                    <tr>
+                                        <td class="text-muted">Boost:</td>
+                                        <td class="text-end text-success">+@lastCheckResult.BoostValue</td>
+                                    </tr>
+                                }
+                                <tr class="border-top">
+                                    <td class="text-muted">Total Roll:</td>
+                                    <td class="text-end"><strong>@(lastCheckResult.Roll + lastCheckResult.EffectiveAbilityScore)</strong></td>
+                                </tr>
+                                <tr>
+                                    <td class="text-muted">Target Value (TV):</td>
+                                    <td class="text-end">@lastCheckResult.TargetValue</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="alert @(lastCheckResult.Success ? "alert-success" : "alert-danger") py-2 mb-0">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span>Success Value (SV):</span>
+                            <strong class="fs-5">@FormatSV(lastCheckResult.SuccessValue)</strong>
+                        </div>
+                        <small class="text-muted">
+                            @lastCheckResult.Roll + @lastCheckResult.EffectiveAbilityScore - @lastCheckResult.TargetValue = @lastCheckResult.SuccessValue
+                        </small>
+                    </div>
+
                     @if (!string.IsNullOrEmpty(lastCheckResult.SpecialEffect))
                     {
-                        <p class="text-info small"><i class="bi bi-lightning-fill"></i> @lastCheckResult.SpecialEffect</p>
+                        <p class="text-info small mt-2 mb-0"><i class="bi bi-lightning-fill"></i> @lastCheckResult.SpecialEffect</p>
                     }
                 </div>
             </div>
@@ -179,7 +218,16 @@
     private CheckResult? lastCheckResult;
     private GameMechanics.Reference.SkillList? allSkills;
 
-    private record CheckResult(bool Success, int AbilityScore, int TargetValue, int SuccessValue, string Outcome, string? SpecialEffect);
+    private record CheckResult(
+        bool Success,
+        int Roll,
+        int BaseAbilityScore,
+        int BoostValue,
+        int EffectiveAbilityScore,
+        int TargetValue,
+        int SuccessValue,
+        string Outcome,
+        string? SpecialEffect);
 
     protected override async Task OnInitializedAsync()
     {
@@ -337,7 +385,16 @@
         }
 
         string outcome = success ? GetSuccessOutcome(successValue) : GetFailureOutcome(successValue);
-        lastCheckResult = new CheckResult(success, effectiveAS, targetValue, successValue, outcome, specialEffect);
+        lastCheckResult = new CheckResult(
+            success,
+            roll,
+            selectedSkill.AbilityScore,
+            boostValue,
+            effectiveAS,
+            targetValue,
+            successValue,
+            outcome,
+            specialEffect);
 
         // Notify parent that character changed (for saving)
         await OnCharacterChanged.InvokeAsync();
@@ -362,5 +419,15 @@
             <= -5 => "Bad Failure",
             _ => "Failure"
         };
+    }
+
+    private string FormatRoll(int roll)
+    {
+        return roll >= 0 ? $"+{roll}" : roll.ToString();
+    }
+
+    private string FormatSV(int sv)
+    {
+        return sv >= 0 ? $"+{sv}" : sv.ToString();
     }
 }


### PR DESCRIPTION
## Summary
- Expands the skill check result card to show a full calculation breakdown
- Displays the 4dF+ dice roll, base ability score, boost value (if applied), and target value
- Shows the complete formula: Roll + AS - TV = SV
- Uses formatted display with +/- signs for roll and success values

Closes #52

## Test plan
- [ ] Use a skill from the Skills tab during gameplay
- [ ] Verify the result card shows the detailed calculation breakdown
- [ ] Verify boost values appear when boost is applied
- [ ] Verify positive rolls show with "+" prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)