### PR TITLE
Enhance burst and suppression fire mechanics

### DIFF
--- a/GameMechanics/Combat/FirearmAttackRequest.cs
+++ b/GameMechanics/Combat/FirearmAttackRequest.cs
@@ -105,6 +105,20 @@ public class FirearmAttackRequest
     }
 
     /// <summary>
+    /// Gets the TV penalty for the selected fire mode.
+    /// Burst: +1 TV, Suppression: +3 TV, Single: 0
+    /// </summary>
+    public int GetFireModeTVPenalty()
+    {
+        return FireMode switch
+        {
+            FireMode.Burst => 1,
+            FireMode.Suppression => 3,
+            _ => 0
+        };
+    }
+
+    /// <summary>
     /// Calculates the base TV from range and conditions.
     /// </summary>
     public int CalculateBaseTV()
@@ -113,6 +127,7 @@ public class FirearmAttackRequest
         tv += RangeModifiers.GetTargetMovementModifier(TargetIsMoving, TargetIsProne, TargetIsCrouching);
         tv += RangeModifiers.GetCoverModifier(TargetCover);
         tv += RangeModifiers.GetSizeModifier(TargetSize);
+        tv += GetFireModeTVPenalty();
         return tv;
     }
 

--- a/Threa/Threa.Client/Components/Pages/GamePlay/RangedAttackMode.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/RangedAttackMode.razor
@@ -81,7 +81,8 @@
                                     <button class="btn @(selectedFireMode == FireMode.Burst ? "btn-warning" : "btn-outline-secondary")"
                                             @onclick="() => selectedFireMode = FireMode.Burst">
                                         <i class="bi bi-three-dots"></i> Burst
-                                        <span class="badge bg-dark">@burstSize rounds</span>
+                                        <span class="badge bg-dark">@weapon.BurstSize rounds</span>
+                                        <span class="badge bg-warning text-dark">+1 TV</span>
                                     </button>
                                 }
                                 @if (weapon.SupportsSuppression)
@@ -89,7 +90,8 @@
                                     <button class="btn @(selectedFireMode == FireMode.Suppression ? "btn-warning" : "btn-outline-secondary")"
                                             @onclick="() => selectedFireMode = FireMode.Suppression">
                                         <i class="bi bi-arrows-angle-expand"></i> Suppression
-                                        <span class="badge bg-dark">@suppressiveRounds rounds</span>
+                                        <span class="badge bg-dark">@weapon.SuppressiveRounds rounds</span>
+                                        <span class="badge bg-warning text-dark">+3 TV</span>
                                     </button>
                                 }
                             </div>
@@ -112,17 +114,6 @@
                                 </div>
                             }
 
-                            @if (selectedFireMode == FireMode.Burst)
-                            {
-                                <div class="mt-2">
-                                    <label class="form-label small">Burst Size:</label>
-                                    <div class="d-flex align-items-center gap-2">
-                                        <button class="btn btn-sm btn-secondary" @onclick="() => burstSize = Math.Max(2, burstSize - 1)">-</button>
-                                        <span class="fw-bold">@burstSize</span>
-                                        <button class="btn btn-sm btn-secondary" @onclick="() => burstSize = Math.Min(weapon.LoadedAmmo, burstSize + 1)">+</button>
-                                    </div>
-                                </div>
-                            }
                         }
                     </div>
                 </div>
@@ -373,6 +364,13 @@
                                         <td class="fw-bold">@(RangeModifiers.GetSizeModifier(targetSize) >= 0 ? "+" : "")@RangeModifiers.GetSizeModifier(targetSize)</td>
                                     </tr>
                                 }
+                                @if (GetFireModeTVPenalty() != 0)
+                                {
+                                    <tr>
+                                        <td>Fire Mode (@selectedFireMode):</td>
+                                        <td class="fw-bold">+@GetFireModeTVPenalty()</td>
+                                    </tr>
+                                }
                                 @if (tvAdjustment != 0)
                                 {
                                     <tr>
@@ -577,9 +575,7 @@
                                     <div class="alert alert-success">
                                         <strong>@attackResult.Hits.Count(h => h.Hit) hit(s)!</strong>
                                         <br />
-                                        <span class="fs-4">Total SV: @attackResult.Hits.Where(h => h.Hit).Sum(h => h.SV)</span>
-                                        <br />
-                                        <small>Target should apply total SV @attackResult.Hits.Where(h => h.Hit).Sum(h => h.SV) via Damage Resolution.</small>
+                                        <small>Each hit applies its individual SV via Damage Resolution.</small>
                                     </div>
                                 }
                                 else
@@ -691,8 +687,6 @@
     private TargetSize targetSize = TargetSize.Normal;
     private bool attackerIsMoving;
     private int tvAdjustment;
-    private int burstSize = 3;
-    private int suppressiveRounds = 10;
     private ActionCostType costType = ActionCostType.OneAPOneFat;
     private int boostValue;
     private int boostAPCost;
@@ -712,10 +706,6 @@
             if (weapon.SupportsSingle) selectedFireMode = FireMode.Single;
             else if (weapon.SupportsBurst) selectedFireMode = FireMode.Burst;
             else if (weapon.SupportsSuppression) selectedFireMode = FireMode.Suppression;
-
-            // Clamp burst size to available ammo
-            if (burstSize > weapon.LoadedAmmo)
-                burstSize = Math.Max(2, weapon.LoadedAmmo);
         }
     }
 
@@ -787,12 +777,23 @@
         return av;
     }
 
+    private int GetFireModeTVPenalty()
+    {
+        return selectedFireMode switch
+        {
+            FireMode.Burst => 1,
+            FireMode.Suppression => 3,
+            _ => 0
+        };
+    }
+
     private int GetTV()
     {
         int tv = RangeModifiers.GetBaseTV(selectedRange);
         tv += RangeModifiers.GetTargetMovementModifier(targetIsMoving, targetIsProne, targetIsCrouching);
         tv += RangeModifiers.GetCoverModifier(targetCover);
         tv += RangeModifiers.GetSizeModifier(targetSize);
+        tv += GetFireModeTVPenalty();
         tv += tvAdjustment;
         return tv;
     }
@@ -808,8 +809,8 @@
         return selectedFireMode switch
         {
             FireMode.Single => 1,
-            FireMode.Burst => burstSize,
-            FireMode.Suppression => suppressiveRounds,
+            FireMode.Burst => weapon?.BurstSize ?? 3,
+            FireMode.Suppression => weapon?.SuppressiveRounds ?? 10,
             _ => 1
         };
     }
@@ -906,8 +907,8 @@
             TargetSize = targetSize,
             TVAdjustment = tvAdjustment,
             FireMode = selectedFireMode,
-            BurstSize = burstSize,
-            SuppressiveRounds = suppressiveRounds,
+            BurstSize = weapon.BurstSize,
+            SuppressiveRounds = weapon.SuppressiveRounds,
             BaseSVModifier = weapon.BaseSV,
             CurrentLoadedAmmo = weapon.LoadedAmmo,
             AmmoDamageModifier = weapon.AmmoDamageModifier,
@@ -963,9 +964,7 @@
         else if (attackResult.FireMode == FireMode.Burst)
         {
             var hits = attackResult.Hits.Count(h => h.Hit);
-            var totalSV = attackResult.Hits.Where(h => h.Hit).Sum(h => h.SV);
             message += $": {hits}/{attackResult.Hits.Count} hits";
-            if (hits > 0) message += $", total SV {totalSV}";
         }
         else if (attackResult.FireMode == FireMode.Suppression)
         {

--- a/Threa/Threa.Client/Components/Pages/GamePlay/RangedWeaponInfo.cs
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/RangedWeaponInfo.cs
@@ -76,6 +76,16 @@ public class RangedWeaponInfo
     public bool SupportsBurst { get; set; }
     public bool SupportsSuppression { get; set; }
 
+    /// <summary>
+    /// Number of rounds fired in burst mode (weapon-defined).
+    /// </summary>
+    public int BurstSize { get; set; } = 3;
+
+    /// <summary>
+    /// Number of rounds fired in suppression mode (weapon-defined).
+    /// </summary>
+    public int SuppressiveRounds { get; set; } = 10;
+
     // ========== AOE Properties (from weapon or loaded ammo) ==========
 
     /// <summary>

--- a/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
@@ -397,6 +397,8 @@
                     SupportsSingle = rangedProps?.HasFireMode(FireMode.Single) ?? true,
                     SupportsBurst = rangedProps?.HasFireMode(FireMode.Burst) ?? false,
                     SupportsSuppression = rangedProps?.HasFireMode(FireMode.Suppression) ?? false,
+                    BurstSize = rangedProps?.BurstSize ?? 3,
+                    SuppressiveRounds = rangedProps?.SuppressiveRounds ?? 10,
                     IsAOECapable = isAOECapable,
                     BlastRadius = blastRadius,
                     BlastFalloff = blastFalloff,


### PR DESCRIPTION
## Summary
- Burst and suppression fire now use weapon-defined round counts (no player selection)
- Added +1 TV penalty for burst fire mode
- Added +3 TV penalty for suppression fire mode  
- Removed total SV display from burst results (individual shot SVs still shown)
- Fire mode buttons now show TV penalty badges

Closes #42

## Test plan
- [ ] Equip a weapon with burst fire capability
- [ ] Verify burst fire uses weapon's burst size (no +/- controls)
- [ ] Verify burst fire shows +1 TV penalty in summary
- [ ] Verify burst results show individual hits without total SV
- [ ] Equip a weapon with suppression capability
- [ ] Verify suppression uses weapon's suppressive rounds
- [ ] Verify suppression shows +3 TV penalty in summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)