### PR TITLE
Require table join approval from Play page (#33)

### DIFF
--- a/Threa/Threa.Client/Components/Pages/GamePlay/Play.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/Play.razor
@@ -27,6 +27,8 @@
 @using GameMechanics.Time
 @using Threa.Dal
 
+@inject ITableDal TableDal
+
 <PageTitle>Threa - Play</PageTitle>
 
 @if (errorMessage != null)
@@ -34,6 +36,17 @@
     <div class="alert alert-danger alert-dismissible fade show" role="alert">
         <i class="bi bi-exclamation-triangle-fill me-2"></i>
         <strong>Error:</strong> @errorMessage
+        @if (errorMessage.Contains("not attached to this table"))
+        {
+            <div class="mt-2">
+                <a href="/player/browse-campaigns" class="btn btn-sm btn-outline-primary">
+                    <i class="bi bi-search me-1"></i>Browse Campaigns
+                </a>
+                <a href="/play" class="btn btn-sm btn-outline-secondary ms-2">
+                    <i class="bi bi-arrow-left me-1"></i>Select Character
+                </a>
+            </div>
+        }
         <button type="button" class="btn-close" @onclick="() => errorMessage = null" aria-label="Close"></button>
     </div>
 }
@@ -322,11 +335,20 @@ protected override async Task OnInitializedAsync()
             character = await characterPortal.FetchAsync(CharacterId);
             await LoadEquippedItemsAsync();
 
-            // If TableId is provided, load the table
+            // If TableId is provided, load the table and verify character attachment
             if (TableId != Guid.Empty)
             {
                 try
                 {
+                    // First verify the character is actually attached to this table
+                    var attachedTable = await TableDal.GetTableForCharacterAsync(CharacterId);
+                    if (attachedTable == null || attachedTable.Id != TableId)
+                    {
+                        errorMessage = "This character is not attached to this table. You must request to join the table and be approved by the Game Master before you can play.";
+                        isLoading = false;
+                        return;
+                    }
+
                     table = await tablePortal.FetchAsync(TableId);
                     SubscribeToActivityLog(TableId);
                     await SubscribeToTimeEvents(TableId);

--- a/Threa/Threa.Client/Components/Pages/GamePlay/SelectCharacter.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/SelectCharacter.razor
@@ -13,9 +13,7 @@
 @inject NavigationManager NavigationManager
 @inject ApplicationContext applicationContext
 @inject IDataPortal<GameMechanics.Player.CharacterList> characterListPortal
-@inject IDataPortal<GameMechanics.GamePlay.TableList> tableListPortal
 @inject IDataPortal<GameMechanics.GamePlay.TableCharacterDetacher> detacherPortal
-@inject IDataPortal<GameMechanics.GamePlay.TableCharacterAttacher> attacherPortal
 
 <PageTitle>Threa - Select Character</PageTitle>
 
@@ -119,73 +117,43 @@ else
     </div>
 }
 
-@* Table Selection Dialog *@
-@if (showTableSelection && characterToAttach != null)
+@* Play Options Dialog *@
+@if (showPlayOptions && characterToPlay != null)
 {
     <div class="modal fade show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header bg-primary text-white">
-                    <h5 class="modal-title">Join a Table</h5>
-                    <button type="button" class="btn-close btn-close-white" @onclick="CancelTableSelection"></button>
+                    <h5 class="modal-title">Play Options</h5>
+                    <button type="button" class="btn-close btn-close-white" @onclick="CancelPlayOptions"></button>
                 </div>
                 <div class="modal-body">
-                    <p>Select a table for <strong>@characterToAttach.Name</strong> to join:</p>
+                    <p>Choose how you'd like to play with <strong>@characterToPlay.Name</strong>:</p>
 
-                    @if (availableTables == null)
-                    {
-                        <p>Loading tables...</p>
-                    }
-                    else if (!availableTables.Any())
-                    {
-                        <div class="alert alert-info">
-                            <p>No active tables available.</p>
-                            <p>You can still play without joining a table, or ask a Game Master to create one.</p>
-                        </div>
-                    }
-                    else
-                    {
-                        <div class="list-group mb-3">
-                            @foreach (var tableInfo in availableTables)
-                            {
-                                <button type="button"
-                                        class="list-group-item list-group-item-action d-flex justify-content-between align-items-center @(selectedTableId == tableInfo.Id ? "active" : "")"
-                                        @onclick="() => selectedTableId = tableInfo.Id">
-                                    <div>
-                                        <strong>@tableInfo.Name</strong>
-                                        <br />
-                                        <small>@tableInfo.StatusDisplay - Round @tableInfo.CurrentRound</small>
-                                    </div>
-                                    @if (selectedTableId == tableInfo.Id)
-                                    {
-                                        <i class="bi bi-check-circle-fill"></i>
-                                    }
+                    <div class="d-grid gap-3">
+                        <div class="card">
+                            <div class="card-body">
+                                <h6 class="card-title"><i class="bi bi-person me-2"></i>Solo Play</h6>
+                                <p class="card-text text-muted small">Play without joining a table. Good for practicing or solo adventures.</p>
+                                <button type="button" class="btn btn-outline-primary" @onclick="PlayWithoutTable">
+                                    Play Without Table
                                 </button>
-                            }
+                            </div>
                         </div>
-                    }
+
+                        <div class="card">
+                            <div class="card-body">
+                                <h6 class="card-title"><i class="bi bi-people me-2"></i>Join a Campaign</h6>
+                                <p class="card-text text-muted small">Browse available campaigns and request to join. A Game Master will review your request.</p>
+                                <button type="button" class="btn btn-primary" @onclick="NavigateToBrowseCampaigns">
+                                    Browse Campaigns
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" @onclick="CancelTableSelection">Cancel</button>
-                    <button type="button" class="btn btn-outline-primary" @onclick="PlayWithoutTable">
-                        Play Without Table
-                    </button>
-                    @if (availableTables != null && availableTables.Any())
-                    {
-                        <button type="button" class="btn btn-primary"
-                                @onclick="ConfirmTableSelection"
-                                disabled="@(selectedTableId == Guid.Empty || isAttaching)">
-                            @if (isAttaching)
-                            {
-                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                <span>Joining...</span>
-                            }
-                            else
-                            {
-                                <span>Join Table</span>
-                            }
-                        </button>
-                    }
+                    <button type="button" class="btn btn-secondary" @onclick="CancelPlayOptions">Cancel</button>
                 </div>
             </div>
         </div>
@@ -197,7 +165,6 @@ else
     public Guid PreselectedTableId { get; set; }
 
     private IEnumerable<GameMechanics.Player.CharacterInfo>? availableCharacters;
-    private IEnumerable<GameMechanics.GamePlay.TableInfo>? availableTables;
     private string? errorMessage;
     private int currentPlayerId;
 
@@ -206,11 +173,9 @@ else
     private bool isDetaching;
     private GameMechanics.Player.CharacterInfo? characterToDetach;
 
-    // Table selection state
-    private bool showTableSelection;
-    private bool isAttaching;
-    private GameMechanics.Player.CharacterInfo? characterToAttach;
-    private Guid selectedTableId;
+    // Play options state
+    private bool showPlayOptions;
+    private GameMechanics.Player.CharacterInfo? characterToPlay;
 
     protected override async Task OnInitializedAsync()
     {
@@ -232,20 +197,7 @@ else
         availableCharacters = charList.Where(c => c.IsPlayable);
     }
 
-    private async Task LoadTablesAsync()
-    {
-        try
-        {
-            var tableList = await tableListPortal.FetchAsync();
-            availableTables = tableList.Where(t => t.Status != Threa.Dal.Dto.TableStatus.Ended);
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"Failed to load tables: {ex.Message}";
-        }
-    }
-
-    private async Task SelectCharacterAsync(GameMechanics.Player.CharacterInfo charInfo)
+    private void SelectCharacterAsync(GameMechanics.Player.CharacterInfo charInfo)
     {
         try
         {
@@ -258,19 +210,15 @@ else
             }
             else if (PreselectedTableId != Guid.Empty)
             {
-                // We have a preselected table from the URL - show table selection with it pre-selected
-                characterToAttach = charInfo;
-                selectedTableId = PreselectedTableId;
-                await LoadTablesAsync();
-                showTableSelection = true;
+                // We have a preselected table from the URL - redirect to browse campaigns
+                // The user must go through the approval process to join a table
+                NavigationManager.NavigateTo("/player/browse-campaigns");
             }
             else
             {
-                // Character not attached to a table - show table selection dialog
-                characterToAttach = charInfo;
-                selectedTableId = Guid.Empty;
-                await LoadTablesAsync();
-                showTableSelection = true;
+                // Character not attached to a table - show play options dialog
+                characterToPlay = charInfo;
+                showPlayOptions = true;
             }
         }
         catch (Exception ex)
@@ -325,53 +273,24 @@ else
         }
     }
 
-    // Table selection methods
-    private void CancelTableSelection()
+    // Play options methods
+    private void CancelPlayOptions()
     {
-        showTableSelection = false;
-        characterToAttach = null;
-        selectedTableId = Guid.Empty;
+        showPlayOptions = false;
+        characterToPlay = null;
     }
 
     private void PlayWithoutTable()
     {
-        if (characterToAttach == null) return;
+        if (characterToPlay == null) return;
 
         // Navigate to play page without table
-        NavigationManager.NavigateTo($"/play/{characterToAttach.Id}");
+        NavigationManager.NavigateTo($"/play/{characterToPlay.Id}");
     }
 
-    private async Task ConfirmTableSelection()
+    private void NavigateToBrowseCampaigns()
     {
-        if (characterToAttach == null || selectedTableId == Guid.Empty) return;
-
-        try
-        {
-            isAttaching = true;
-            errorMessage = null;
-
-            var result = await attacherPortal.ExecuteAsync(characterToAttach.Id, selectedTableId, currentPlayerId);
-
-            if (result.Success)
-            {
-                // Navigate to play page with character and table
-                NavigationManager.NavigateTo($"/play/{characterToAttach.Id}/{selectedTableId}");
-            }
-            else
-            {
-                errorMessage = result.ErrorMessage ?? "Failed to join table.";
-            }
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"Failed to join table: {ex.Message}";
-        }
-        finally
-        {
-            isAttaching = false;
-            showTableSelection = false;
-            characterToAttach = null;
-            selectedTableId = Guid.Empty;
-        }
+        // Navigate to browse campaigns page for the proper approval workflow
+        NavigationManager.NavigateTo("/player/browse-campaigns");
     }
 }


### PR DESCRIPTION
## Summary
- Removes direct table joining from SelectCharacter page, which was bypassing the approval workflow
- Changes SelectCharacter to show play options dialog with choices for solo play or browsing campaigns
- Adds validation in Play page to verify character is actually attached to the specified table
- Shows helpful error message with links to browse campaigns or select character if not attached

## Test plan
- [ ] Navigate to `/play` and select a character not attached to a table
- [ ] Verify the play options dialog shows "Solo Play" and "Browse Campaigns" options
- [ ] Click "Browse Campaigns" and verify it navigates to `/player/browse-campaigns`
- [ ] Click "Play Without Table" and verify it navigates to `/play/{characterId}` (solo mode)
- [ ] Try to directly access `/play/{characterId}/{tableId}` with a character not attached to that table
- [ ] Verify an error message is shown with helpful links
- [ ] Verify characters already attached to a table can still navigate directly to play

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)