### PR TITLE
Fix ammo containers not working in reload and combat

### DIFF
--- a/Threa/Threa.Client/Components/Pages/GamePlay/AmmoSourceInfo.cs
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/AmmoSourceInfo.cs
@@ -82,6 +82,11 @@ public class ReloadCompleteData
     /// Remaining ammo in the source after reload.
     /// </summary>
     public int AmmoSourceRemaining { get; set; }
+
+    /// <summary>
+    /// Whether the ammo source was loose ammo (vs a magazine).
+    /// </summary>
+    public bool IsLooseAmmo { get; set; }
 }
 
 /// <summary>

--- a/Threa/Threa.Client/Components/Pages/GamePlay/RangedWeaponInfo.cs
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/RangedWeaponInfo.cs
@@ -60,6 +60,22 @@ public class RangedWeaponInfo
     public string? AcceptedAmmoType { get; set; }
 
     /// <summary>
+    /// How the weapon is reloaded (Magazine, SingleRound, Cylinder, etc.).
+    /// Used to filter compatible ammo sources.
+    /// </summary>
+    public string ReloadType { get; set; } = "Magazine";
+
+    /// <summary>
+    /// Whether the weapon can accept loose ammo directly (arrows, individual rounds).
+    /// </summary>
+    public bool AcceptsLooseAmmo { get; set; }
+
+    /// <summary>
+    /// ID of the currently loaded magazine (if any).
+    /// </summary>
+    public Guid? LoadedMagazineId { get; set; }
+
+    /// <summary>
     /// Damage modifier from special ammo.
     /// </summary>
     public int AmmoDamageModifier { get; set; }

--- a/Threa/Threa.Client/Components/Pages/GamePlay/ReloadMode.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/ReloadMode.razor
@@ -365,8 +365,9 @@
     }
 
     /// <summary>
-    /// Gets ammo sources that are compatible with the selected weapon's ammo type.
+    /// Gets ammo sources that are compatible with the selected weapon's ammo type and reload type.
     /// Uses the weapon's AcceptedAmmoType (what it can use) rather than LoadedAmmoType (what's currently loaded).
+    /// Filters out loose ammo if the weapon doesn't accept it, and filters out magazines if incompatible with reload type.
     /// </summary>
     private IEnumerable<AmmoSourceInfo> GetCompatibleAmmoSources()
     {
@@ -377,9 +378,30 @@
         if (string.IsNullOrEmpty(weaponAmmoType))
             return Enumerable.Empty<AmmoSourceInfo>();
 
-        return AvailableMagazines.Where(m => 
-            string.Equals(m.AmmoType, weaponAmmoType, StringComparison.OrdinalIgnoreCase) &&
-            m.CurrentAmmo > 0);
+        return AvailableMagazines.Where(m =>
+        {
+            // Check ammo type compatibility
+            if (!string.Equals(m.AmmoType, weaponAmmoType, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            // Must have ammo available
+            if (m.CurrentAmmo <= 0)
+                return false;
+
+            // Check if this ammo source is compatible with the weapon's reload type
+            if (m.IsLooseAmmo)
+            {
+                // Loose ammo is only valid if the weapon accepts loose ammo
+                return selectedWeapon.AcceptsLooseAmmo;
+            }
+            else
+            {
+                // Magazines are valid for Magazine reload type weapons that don't require loose ammo
+                // (or when AcceptsLooseAmmo is false, meaning it requires a container)
+                return !selectedWeapon.AcceptsLooseAmmo ||
+                       selectedWeapon.ReloadType.Equals("Magazine", StringComparison.OrdinalIgnoreCase);
+            }
+        });
     }
 
     private string GetAmmoBadgeClass(RangedWeaponInfo weapon)
@@ -572,7 +594,8 @@
             AmmoSourceItemId = selectedMagazine.ItemId,
             RoundsLoaded = reloadResult.RoundsLoaded,
             NewWeaponAmmoCount = reloadResult.NewAmmoCount,
-            AmmoSourceRemaining = reloadResult.AmmoSourceRemaining
+            AmmoSourceRemaining = reloadResult.AmmoSourceRemaining,
+            IsLooseAmmo = selectedMagazine.IsLooseAmmo
         };
 
         await OnReloadComplete.InvokeAsync(completeData);
@@ -597,7 +620,8 @@
             AmmoSourceItemId = Guid.Empty, // Don't update ammo source yet
             RoundsLoaded = 0, // No immediate change
             NewWeaponAmmoCount = selectedWeapon.LoadedAmmo, // Current (unchanged)
-            AmmoSourceRemaining = selectedMagazine.CurrentAmmo // Current (unchanged)
+            AmmoSourceRemaining = selectedMagazine.CurrentAmmo, // Current (unchanged)
+            IsLooseAmmo = selectedMagazine.IsLooseAmmo
         };
 
         await OnReloadComplete.InvokeAsync(completeData);

--- a/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
@@ -464,6 +464,9 @@
                     Capacity = rangedProps?.Capacity ?? 0,
                     LoadedAmmoType = ammoState.LoadedAmmoType,
                     AcceptedAmmoType = rangedProps?.AmmoType,
+                    ReloadType = rangedProps?.ReloadType ?? "Magazine",
+                    AcceptsLooseAmmo = rangedProps?.AcceptsLooseAmmo ?? false,
+                    LoadedMagazineId = ammoState.LoadedMagazineId,
                     AmmoDamageModifier = 0, // Will be calculated from loaded ammo type
                     IsDodgeable = rangedProps?.IsDodgeable ?? true,
                     SupportsSingle = rangedProps?.HasFireMode(FireMode.Single) ?? true,
@@ -859,9 +862,32 @@
                 if (item != null)
                 {
                     var ammoState = WeaponAmmoState.FromJson(item.CustomProperties);
+                    var previousAmmo = ammoState.LoadedAmmo;
                     ammoState.LoadedAmmo = data.AmmoRemaining;
                     item.CustomProperties = WeaponAmmoState.MergeIntoCustomProperties(item.CustomProperties, ammoState);
                     await CharacterItemDal.UpdateItemAsync(item);
+
+                    // If weapon has a loaded magazine, update its state too
+                    if (ammoState.LoadedMagazineId.HasValue)
+                    {
+                        var magazineItem = await CharacterItemDal.GetItemAsync(ammoState.LoadedMagazineId.Value);
+                        if (magazineItem != null)
+                        {
+                            var magazineState = AmmoContainerState.FromJson(magazineItem.CustomProperties);
+                            // Deduct the same amount of ammo consumed from the magazine
+                            var ammoConsumed = previousAmmo - data.AmmoRemaining;
+                            magazineState.LoadedAmmo = Math.Max(0, magazineState.LoadedAmmo - ammoConsumed);
+                            magazineItem.CustomProperties = AmmoContainerState.MergeIntoCustomProperties(magazineItem.CustomProperties, magazineState);
+                            await CharacterItemDal.UpdateItemAsync(magazineItem);
+
+                            // Update local cache if present
+                            var cachedMag = availableAmmoSources.FirstOrDefault(a => a.ItemId == ammoState.LoadedMagazineId.Value);
+                            if (cachedMag != null)
+                            {
+                                cachedMag.CurrentAmmo = magazineState.LoadedAmmo;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -881,6 +907,8 @@
             if (weapon != null)
             {
                 weapon.LoadedAmmo = data.NewWeaponAmmoCount;
+                // Track if a magazine is loaded (not loose ammo)
+                weapon.LoadedMagazineId = data.IsLooseAmmo ? null : data.AmmoSourceItemId;
 
                 // Update the weapon item in the database
                 var weaponItem = equippedItems.FirstOrDefault(i => i.Id == data.WeaponItemId);
@@ -888,6 +916,8 @@
                 {
                     var ammoState = WeaponAmmoState.FromJson(weaponItem.CustomProperties);
                     ammoState.LoadedAmmo = data.NewWeaponAmmoCount;
+                    // Set LoadedMagazineId when loading from a magazine, clear it when loading loose ammo
+                    ammoState.LoadedMagazineId = data.IsLooseAmmo ? null : data.AmmoSourceItemId;
                     weaponItem.CustomProperties = WeaponAmmoState.MergeIntoCustomProperties(weaponItem.CustomProperties, ammoState);
                     await CharacterItemDal.UpdateItemAsync(weaponItem);
                 }


### PR DESCRIPTION
## Summary
- Fixed reload dialog to filter ammo sources based on weapon's reload type (weapons that don't accept loose ammo will only show magazines)
- Added tracking of LoadedMagazineId when loading a magazine into a weapon
- When firing, update both weapon's ammo state AND the loaded magazine's state

## Changes
- `RangedWeaponInfo.cs`: Added `ReloadType`, `AcceptsLooseAmmo`, and `LoadedMagazineId` properties
- `AmmoSourceInfo.cs`: Added `IsLooseAmmo` to `ReloadCompleteData`
- `ReloadMode.razor`: Updated `GetCompatibleAmmoSources()` to filter based on weapon reload compatibility
- `TabCombat.razor`: Track magazine ID on reload, update magazine state when firing

## Test plan
- [ ] Create a weapon that requires a magazine (doesn't accept loose ammo)
- [ ] Verify reload dialog only shows magazines, not loose ammo
- [ ] Load a magazine into the weapon
- [ ] Verify weapon shows correct ammo count from magazine
- [ ] Fire the weapon
- [ ] Verify magazine ammo count decreases (not deleted)
- [ ] Test with weapon that accepts loose ammo - both options should appear

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)