### PR TITLE
Apply fantasy theme styling to GM static data pages

### DIFF
--- a/Threa/Threa.Client/Components/Pages/GameMaster/ItemEdit.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/ItemEdit.razor
@@ -17,24 +17,46 @@
 @inject Threa.Services.RenderModeProvider RenderModeProvider
 @inject NavigationManager NavigationManager
 
-<h3>@(IsNewItem ? "Add New Item" : "Edit Item")</h3>
+<div class="info-box d-flex justify-content-between align-items-center">
+    <div>
+        <strong>@(IsNewItem ? "Add New Item" : $"Edit: {vm.Model?.Name ?? "Item"}")</strong>
+        @if (vm.Model != null)
+        {
+            <span class="badge ms-2 @(vm.Model.IsActive ? "bg-success" : "bg-warning")">
+                @(vm.Model.IsActive ? "Active" : "Inactive")
+            </span>
+        }
+    </div>
+    <a href="/gamemaster/items" class="btn btn-outline-secondary btn-sm">Back to Items</a>
+</div>
 
-<div class="alert-danger">@vm.ViewModelErrorText</div>
+@if (!string.IsNullOrEmpty(vm.ViewModelErrorText))
+{
+    <div class="alert alert-danger">@vm.ViewModelErrorText</div>
+}
 
 @if (vm.Model == null)
 {
-    <p>Loading...</p>
+    <div class="card">
+        <div class="card-body text-center py-4">
+            <div class="item-meta">Loading item...</div>
+        </div>
+    </div>
 }
 else
 {
-    <div class="item-edit-form">
-        <RadzenTabs @bind-SelectedIndex="@selectedTabIndex" @key="@($"tabs-{vm.Model.ItemType}")">
-            <Tabs>
-                <!-- ========================== -->
-                <!-- BASIC TAB (Always visible) -->
-                <!-- ========================== -->
-                <RadzenTabsItem Text="Basic">
-                    <table class="table table-sm">
+    <div class="item-edit-form card">
+        <div class="card-body">
+            <RadzenTabs @bind-SelectedIndex="@selectedTabIndex" @key="@($"tabs-{vm.Model.ItemType}")">
+                <Tabs>
+                    <!-- ========================== -->
+                    <!-- BASIC TAB (Always visible) -->
+                    <!-- ========================== -->
+                    <RadzenTabsItem Text="Basic">
+                        <div class="info-box mt-3">
+                            <strong>Basic Properties</strong>
+                        </div>
+                        <table class="table table-sm">
                         <tbody>
                             <TextInputRow Property="vm.GetPropertyInfo<string>(() => vm.Model.Name)" />
                             <TextAreaRow Property="vm.GetPropertyInfo<string>(() => vm.Model.Description)" />
@@ -139,13 +161,16 @@ else
                     </table>
                 </RadzenTabsItem>
 
-                <!-- ========================== -->
-                <!-- WEAPON TAB -->
-                <!-- ========================== -->
-                @if (vm.Model.ItemType == ItemType.Weapon)
-                {
-                    <RadzenTabsItem Text="Weapon">
-                        <table class="table table-sm">
+                    <!-- ========================== -->
+                    <!-- WEAPON TAB -->
+                    <!-- ========================== -->
+                    @if (vm.Model.ItemType == ItemType.Weapon)
+                    {
+                        <RadzenTabsItem Text="Weapon">
+                            <div class="info-box mt-3">
+                                <strong>Weapon Properties</strong>
+                            </div>
+                            <table class="table table-sm">
                             <tbody>
                                 <tr>
                                     <td>Weapon Type</td>
@@ -213,7 +238,9 @@ else
 
                         @if (IsRangedWeaponType)
                         {
-                            <h5 class="mt-4 mb-3">Ranged Weapon Properties</h5>
+                            <div class="info-box mt-4">
+                                <strong>Ranged Weapon Properties</strong>
+                            </div>
                             <table class="table table-sm">
                                 <tbody>
                                     <tr>
@@ -423,13 +450,16 @@ else
                     </RadzenTabsItem>
                 }
 
-                <!-- ========================== -->
-                <!-- ARMOR TAB -->
-                <!-- ========================== -->
-                @if (vm.Model.ItemType == ItemType.Armor || vm.Model.ItemType == ItemType.Shield)
-                {
-                    <RadzenTabsItem Text="Armor">
-                        <table class="table table-sm">
+                    <!-- ========================== -->
+                    <!-- ARMOR TAB -->
+                    <!-- ========================== -->
+                    @if (vm.Model.ItemType == ItemType.Armor || vm.Model.ItemType == ItemType.Shield)
+                    {
+                        <RadzenTabsItem Text="Armor">
+                            <div class="info-box mt-3">
+                                <strong>Armor Properties</strong>
+                            </div>
+                            <table class="table table-sm">
                             <tbody>
                                 <NumericSelectorRow Property="vm.GetPropertyInfo<int>(() => vm.Model.DodgeModifier)" />
 
@@ -484,13 +514,16 @@ else
                     </RadzenTabsItem>
                 }
 
-                <!-- ========================== -->
-                <!-- CONTAINER TAB -->
-                <!-- ========================== -->
-                @if (vm.Model.ItemType == ItemType.Container)
-                {
-                    <RadzenTabsItem Text="Container">
-                        <table class="table table-sm">
+                    <!-- ========================== -->
+                    <!-- CONTAINER TAB -->
+                    <!-- ========================== -->
+                    @if (vm.Model.ItemType == ItemType.Container)
+                    {
+                        <RadzenTabsItem Text="Container">
+                            <div class="info-box mt-3">
+                                <strong>Container Properties</strong>
+                            </div>
+                            <table class="table table-sm">
                             <tbody>
                                 <tr>
                                     <td>Max Weight (lbs)</td>
@@ -529,13 +562,16 @@ else
                     </RadzenTabsItem>
                 }
 
-                <!-- ========================== -->
-                <!-- AMMUNITION TAB -->
-                <!-- ========================== -->
-                @if (vm.Model.ItemType == ItemType.Ammunition)
-                {
-                    <RadzenTabsItem Text="Ammunition">
-                        <table class="table table-sm">
+                    <!-- ========================== -->
+                    <!-- AMMUNITION TAB -->
+                    <!-- ========================== -->
+                    @if (vm.Model.ItemType == ItemType.Ammunition)
+                    {
+                        <RadzenTabsItem Text="Ammunition">
+                            <div class="info-box mt-3">
+                                <strong>Ammunition Properties</strong>
+                            </div>
+                            <table class="table table-sm">
                             <tbody>
                                 <tr>
                                     <td>Ammo Type</td>
@@ -611,13 +647,16 @@ else
                     </RadzenTabsItem>
                 }
 
-                <!-- ========================== -->
-                <!-- AMMO CONTAINER TAB -->
-                <!-- ========================== -->
-                @if (vm.Model.ItemType == ItemType.AmmoContainer)
-                {
-                    <RadzenTabsItem Text="Ammo Container">
-                        <table class="table table-sm">
+                    <!-- ========================== -->
+                    <!-- AMMO CONTAINER TAB -->
+                    <!-- ========================== -->
+                    @if (vm.Model.ItemType == ItemType.AmmoContainer)
+                    {
+                        <RadzenTabsItem Text="Ammo Container">
+                            <div class="info-box mt-3">
+                                <strong>Ammo Container Properties</strong>
+                            </div>
+                            <table class="table table-sm">
                             <tbody>
                                 <tr>
                                     <td>Ammo Type</td>
@@ -660,8 +699,9 @@ else
                         </table>
                     </RadzenTabsItem>
                 }
-            </Tabs>
-        </RadzenTabs>
+                </Tabs>
+            </RadzenTabs>
+        </div>
 
         <!-- ========================== -->
         <!-- SAVE/CANCEL BUTTONS (Sticky bottom bar) -->

--- a/Threa/Threa.Client/Components/Pages/GameMaster/Items.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/Items.razor
@@ -13,37 +13,66 @@
 
 @attribute [Authorize(Roles = "GameMaster,Administrator")]
 
-<h3>Manage Items</h3>
+<div class="info-box d-flex justify-content-between align-items-center">
+    <div>
+        <strong>Manage Items</strong>
+        @if (filteredItems != null)
+        {
+            <span class="item-meta ms-3">Showing @filteredItems.Count() of @(allItems?.Count() ?? 0) items</span>
+        }
+    </div>
+    <a href="/gamemaster/items/new" class="btn btn-primary btn-sm">Add New Item</a>
+</div>
 
-<div class="alert-danger">@vm.ViewModelErrorText</div>
+@if (!string.IsNullOrEmpty(vm.ViewModelErrorText))
+{
+    <div class="alert alert-danger">@vm.ViewModelErrorText</div>
+}
 
 @if (vm.Model == null)
 {
-    <div>Loading...</div>
-    <img src="images/busy.gif" class="busy-animation" />
+    <div class="card">
+        <div class="card-body text-center py-4">
+            <div class="item-meta mb-2">Loading items...</div>
+            <img src="images/busy.gif" class="busy-animation" />
+        </div>
+    </div>
 }
 else
 {
-    <a href="/gamemaster/items/new" class="btn btn-primary mb-3">Add New Item</a>
-
-    <div class="d-flex gap-3 mb-3 align-items-center">
-        <RadzenTextBox @bind-Value="@searchText" Placeholder="Search items..."
-            @oninput="@((e) => OnSearchInput(e.Value?.ToString() ?? ""))"
-            Style="width: 300px" />
-        <RadzenDropDown TValue="ItemType?" Data="@itemTypes"
-            @bind-Value="@selectedType" Change="@(_ => ApplyFilters())"
-            Placeholder="Filter by Type" AllowClear="true" Style="width: 200px" />
+    <div class="card">
+        <div class="card-header d-flex gap-3 align-items-center flex-wrap">
+            <RadzenTextBox @bind-Value="@searchText" Placeholder="Search items..."
+                @oninput="@((e) => OnSearchInput(e.Value?.ToString() ?? ""))"
+                Style="width: 300px" />
+            <RadzenDropDown TValue="ItemType?" Data="@itemTypes"
+                @bind-Value="@selectedType" Change="@(_ => ApplyFilters())"
+                Placeholder="Filter by Type" AllowClear="true" Style="width: 200px" />
+        </div>
+        <div class="card-body p-0">
+            <RadzenDataGrid Data="@filteredItems" TItem="ItemTemplateInfo"
+                AllowSorting="true" AllowPaging="true" PageSize="20"
+                RowSelect="@(item => NavigationManager.NavigateTo($"/gamemaster/items/{item.Id}"))"
+                Style="cursor: pointer">
+                <Columns>
+                    <RadzenDataGridColumn TItem="ItemTemplateInfo" Property="Name" Title="Name" Sortable="true" Width="300px" />
+                    <RadzenDataGridColumn TItem="ItemTemplateInfo" Property="ItemType" Title="Type" Sortable="true" Width="150px" />
+                    <RadzenDataGridColumn TItem="ItemTemplateInfo" Title="Status" Width="100px">
+                        <Template Context="item">
+                            @if (item.IsActive)
+                            {
+                                <span class="text-positive">Active</span>
+                            }
+                            else
+                            {
+                                <span class="text-negative">Inactive</span>
+                            }
+                        </Template>
+                    </RadzenDataGridColumn>
+                </Columns>
+            </RadzenDataGrid>
+        </div>
     </div>
-
-    <RadzenDataGrid Data="@filteredItems" TItem="ItemTemplateInfo"
-        AllowSorting="true" AllowPaging="true" PageSize="20"
-        RowSelect="@(item => NavigationManager.NavigateTo($"/gamemaster/items/{item.Id}"))"
-        Style="cursor: pointer">
-        <Columns>
-            <RadzenDataGridColumn TItem="ItemTemplateInfo" Property="Name" Title="Name" Sortable="true" Width="300px" />
-            <RadzenDataGridColumn TItem="ItemTemplateInfo" Property="ItemType" Title="Type" Sortable="true" Width="150px" />
-        </Columns>
-    </RadzenDataGrid>
 }
 
 @code {

--- a/Threa/Threa.Client/Components/Pages/GameMaster/MagicSchoolEdit.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/MagicSchoolEdit.razor
@@ -12,22 +12,46 @@
 @inject Threa.Services.RenderModeProvider RenderModeProvider
 @inject NavigationManager NavigationManager
 
-<h3>@(IsNewSchool ? "Add New Magic School" : "Edit Magic School")</h3>
+<div class="info-box d-flex justify-content-between align-items-center">
+    <div>
+        <strong>@(IsNewSchool ? "Add New Magic School" : $"Edit: {vm.Model?.Name ?? "School"}")</strong>
+        @if (vm.Model != null)
+        {
+            <span class="badge ms-2 @(vm.Model.IsActive ? "bg-success" : "bg-warning")">
+                @(vm.Model.IsActive ? "Active" : "Inactive")
+            </span>
+            @if (vm.Model.IsCore)
+            {
+                <span class="badge-purple ms-1">Core</span>
+            }
+        }
+    </div>
+    <a href="/gamemaster/magicschools" class="btn btn-outline-secondary btn-sm">Back to Magic Schools</a>
+</div>
 
-<div class="alert-danger">@vm.ViewModelErrorText</div>
+@if (!string.IsNullOrEmpty(vm.ViewModelErrorText))
+{
+    <div class="alert alert-danger">@vm.ViewModelErrorText</div>
+}
 
 @if (vm.Model == null)
 {
-    <p>Loading...</p>
+    <div class="card">
+        <div class="card-body text-center py-4">
+            <div class="item-meta">Loading magic school...</div>
+        </div>
+    </div>
 }
 else
 {
-    <table>
-        <thead>
-            <tr><th></th><th></th></tr>
-        </thead>
-        <tbody>
-            <tr><td colspan="2"><h4>Basic Information</h4></td></tr>
+    <div class="card">
+        <div class="card-body">
+            <table class="table table-sm">
+                <thead>
+                    <tr><th></th><th></th></tr>
+                </thead>
+                <tbody>
+                    <tr><td colspan="2"><div class="info-box card-header-purple"><strong>Basic Information</strong></div></td></tr>
             
             @if (IsNewSchool)
             {
@@ -51,8 +75,8 @@ else
             <TextInputRow Property="vm.GetPropertyInfo<string>(() => vm.Model.ShortDescription)" />
             <TextAreaRow Property="vm.GetPropertyInfo<string>(() => vm.Model.Description)" />
 
-            <tr><td colspan="2"><hr /></td></tr>
-            <tr><td colspan="2"><h4>Visual Properties</h4></td></tr>
+                    <tr><td colspan="2"><hr /></td></tr>
+                    <tr><td colspan="2"><div class="info-box"><strong>Visual Properties</strong></div></td></tr>
 
             <tr>
                 <td>Color Code</td>
@@ -67,8 +91,8 @@ else
 
             <TextInputRow Property="vm.GetPropertyInfo<string?>(() => vm.Model.IconUrl)" />
 
-            <tr><td colspan="2"><hr /></td></tr>
-            <tr><td colspan="2"><h4>Configuration</h4></td></tr>
+                    <tr><td colspan="2"><hr /></td></tr>
+                    <tr><td colspan="2"><div class="info-box"><strong>Configuration</strong></div></td></tr>
 
             <TextInputRow Property="vm.GetPropertyInfo<string>(() => vm.Model.ManaSkillId)" />
             <NumericSelectorRow Property="vm.GetPropertyInfo<int>(() => vm.Model.DisplayOrder)" />
@@ -87,23 +111,25 @@ else
                 </tr>
             }
 
-            <tr><td colspan="2"><hr /></td></tr>
-            <tr><td colspan="2">
-                <div class="alert alert-info">
-                    <strong>Note:</strong> After creating a magic school, you'll need to:
-                    <ul class="mb-0">
-                        <li>Create a corresponding mana skill (e.g., "shadow-mana")</li>
-                        <li>Create spell skills for this school</li>
-                        <li>Update spell definitions to use this school</li>
-                    </ul>
-                </div>
-            </td></tr>
-        </tbody>
-    </table>
-    
-    <div class="mt-3">
-        <button type="button" @onclick="SaveData" class="btn btn-primary" disabled="@(!vm.Model.IsSavable)">Save</button>
-        <button type="button" @onclick="Cancel" class="btn btn-secondary ms-2">Cancel</button>
+                    <tr><td colspan="2"><hr /></td></tr>
+                    <tr><td colspan="2">
+                        <div class="alert alert-info">
+                            <strong>Note:</strong> After creating a magic school, you'll need to:
+                            <ul class="mb-0">
+                                <li>Create a corresponding mana skill (e.g., "shadow-mana")</li>
+                                <li>Create spell skills for this school</li>
+                                <li>Update spell definitions to use this school</li>
+                            </ul>
+                        </div>
+                    </td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="card-footer">
+            <button type="button" @onclick="SaveData" class="btn btn-primary" disabled="@(!vm.Model.IsSavable)">Save</button>
+            <button type="button" @onclick="Cancel" class="btn btn-secondary ms-2">Cancel</button>
+        </div>
     </div>
 }
 

--- a/Threa/Threa.Client/Components/Pages/GameMaster/MagicSchools.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/MagicSchools.razor
@@ -9,60 +9,81 @@
 
 @attribute [Authorize(Roles = "GameMaster,Administrator")]
 
-<h3>Manage Magic Schools</h3>
+<div class="info-box d-flex justify-content-between align-items-center">
+    <div>
+        <strong>Manage Magic Schools</strong>
+        @if (schools != null)
+        {
+            <span class="item-meta ms-3">@schools.Count() schools defined</span>
+        }
+    </div>
+    <a href="/gamemaster/magicschools/new" class="btn btn-primary btn-sm">Add New School</a>
+</div>
 
-<div class="alert-danger">@vm.ViewModelErrorText</div>
+@if (!string.IsNullOrEmpty(vm.ViewModelErrorText))
+{
+    <div class="alert alert-danger">@vm.ViewModelErrorText</div>
+}
 
 @if (vm.Model == null)
 {
-    <div>Loading...</div>
-    <img src="images/busy.gif" class="busy-animation" />
+    <div class="card">
+        <div class="card-body text-center py-4">
+            <div class="item-meta mb-2">Loading magic schools...</div>
+            <img src="images/busy.gif" class="busy-animation" />
+        </div>
+    </div>
 }
 else
 {
-    <a href="/gamemaster/magicschools/new" class="btn btn-primary mb-3">Add New School</a>
-    
-    <QuickGrid Items="schools">
-        <TemplateColumn Title="Color">
-            <div style="width: 30px; height: 30px; background-color: @context.ColorCode; border: 1px solid #ccc; border-radius: 4px;"></div>
-        </TemplateColumn>
-        <PropertyColumn Title="Name" Property="@(p => p.Name)" Sortable="true" />
-        <PropertyColumn Title="Description" Property="@(p => p.ShortDescription)" />
-        <PropertyColumn Title="Order" Property="@(p => p.DisplayOrder)" Sortable="true" />
-        <TemplateColumn Title="Type">
-            @if (context.IsCore)
-            {
-                <span class="badge bg-primary">Core</span>
-            }
-            else
-            {
-                <span class="badge bg-secondary">Custom</span>
-            }
-        </TemplateColumn>
-        <TemplateColumn Title="Status">
-            @if (context.IsActive)
-            {
-                <span class="badge bg-success">Active</span>
-            }
-            else
-            {
-                <span class="badge bg-warning">Inactive</span>
-            }
-        </TemplateColumn>
-        <TemplateColumn Title="Actions">
-            <a href="/gamemaster/magicschools/@context.Id">Edit</a>
-            @if (context.CanBeDeleted)
-            {
-                <text> | </text>
-                <a href="/gamemaster/magicschools/@context.Id/delete" class="btn btn-link btn-sm">Delete</a>
-            }
-            else
-            {
-                <text> | </text>
-                <span class="text-muted" title="Core magic schools cannot be deleted">Delete</span>
-            }
-        </TemplateColumn>
-    </QuickGrid>
+    <div class="card">
+        <div class="card-body p-0">
+            <QuickGrid Items="schools" Class="table table-hover">
+                <TemplateColumn Title="Color">
+                    <div class="d-flex align-items-center gap-2">
+                        <div style="width: 24px; height: 24px; background-color: @context.ColorCode; border: 1px solid var(--color-card-border); border-radius: 4px;"></div>
+                        <span class="item-meta">@context.ColorCode</span>
+                    </div>
+                </TemplateColumn>
+                <PropertyColumn Title="Name" Property="@(p => p.Name)" Sortable="true" />
+                <PropertyColumn Title="Description" Property="@(p => p.ShortDescription)" />
+                <PropertyColumn Title="Order" Property="@(p => p.DisplayOrder)" Sortable="true" />
+                <TemplateColumn Title="Type">
+                    @if (context.IsCore)
+                    {
+                        <span class="badge-purple">Core</span>
+                    }
+                    else
+                    {
+                        <span class="badge bg-secondary">Custom</span>
+                    }
+                </TemplateColumn>
+                <TemplateColumn Title="Status">
+                    @if (context.IsActive)
+                    {
+                        <span class="text-positive">Active</span>
+                    }
+                    else
+                    {
+                        <span class="text-negative">Inactive</span>
+                    }
+                </TemplateColumn>
+                <TemplateColumn Title="Actions">
+                    <a href="/gamemaster/magicschools/@context.Id">Edit</a>
+                    @if (context.CanBeDeleted)
+                    {
+                        <text> | </text>
+                        <a href="/gamemaster/magicschools/@context.Id/delete" class="text-negative">Delete</a>
+                    }
+                    else
+                    {
+                        <text> | </text>
+                        <span class="text-neutral" title="Core magic schools cannot be deleted">Delete</span>
+                    }
+                </TemplateColumn>
+            </QuickGrid>
+        </div>
+    </div>
 }
 
 @code {

--- a/Threa/Threa.Client/Components/Pages/GameMaster/SkillEdit.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/SkillEdit.razor
@@ -13,23 +13,48 @@
 @inject Threa.Services.RenderModeProvider RenderModeProvider
 @inject NavigationManager NavigationManager
 
-<h3>@(IsNewSkill ? "Add New Skill" : "Edit Skill")</h3>
+<div class="info-box d-flex justify-content-between align-items-center">
+    <div>
+        <strong>@(IsNewSkill ? "Add New Skill" : $"Edit: {vm.Model?.Name ?? "Skill"}")</strong>
+        @if (vm.Model != null)
+        {
+            var skillType = vm.Model.IsSpecialized ? "Specialized" : (vm.Model.IsMagic ? "Magic" : "Standard");
+            var badgeClass = skillType switch
+            {
+                "Magic" => "badge-purple",
+                "Specialized" => "badge bg-info",
+                _ => "badge bg-secondary"
+            };
+            <span class="badge ms-2 @badgeClass">@skillType</span>
+        }
+    </div>
+    <a href="/gamemaster/skills" class="btn btn-outline-secondary btn-sm">Back to Skills</a>
+</div>
 
-<div class="alert-danger">@vm.ViewModelErrorText</div>
+@if (!string.IsNullOrEmpty(vm.ViewModelErrorText))
+{
+    <div class="alert alert-danger">@vm.ViewModelErrorText</div>
+}
 
 @if (vm.Model == null)
 {
-    <p>Loading...</p>
+    <div class="card">
+        <div class="card-body text-center py-4">
+            <div class="item-meta">Loading skill...</div>
+        </div>
+    </div>
 }
 else
 {
-    <table>
-        <thead>
-            <tr><th></th><th></th></tr>
-        </thead>
-        <tbody>
-            <!-- Common Properties (All Skills) -->
-            <tr><td colspan="2"><h4>Basic Information</h4></td></tr>
+    <div class="card">
+        <div class="card-body">
+            <table class="table table-sm">
+                <thead>
+                    <tr><th></th><th></th></tr>
+                </thead>
+                <tbody>
+                    <!-- Common Properties (All Skills) -->
+                    <tr><td colspan="2"><div class="info-box"><strong>Basic Information</strong></div></td></tr>
             
             @if (IsNewSkill)
             {
@@ -70,8 +95,8 @@ else
             <CheckBoxRow Property="vm.GetPropertyInfo<bool>(() => vm.Model.IsTheology)" />
             <CheckBoxRow Property="vm.GetPropertyInfo<bool>(() => vm.Model.IsPsionic)" />
 
-            <tr><td colspan="2"><hr /></td></tr>
-            <tr><td colspan="2"><h4>Attributes & Training Costs</h4></td></tr>
+                    <tr><td colspan="2"><hr /></td></tr>
+                    <tr><td colspan="2"><div class="info-box"><strong>Attributes & Training Costs</strong></div></td></tr>
             <tr>
                 <td colspan="2">
                     <small class="text-muted">
@@ -105,8 +130,8 @@ else
             <NumericSelectorRow Property="vm.GetPropertyInfo<int>(() => vm.Model.Untrained)" />
             <NumericSelectorRow Property="vm.GetPropertyInfo<int>(() => vm.Model.Trained)" />
 
-            <tr><td colspan="2"><hr /></td></tr>
-            <tr><td colspan="2"><h4>Action Properties</h4></td></tr>
+                    <tr><td colspan="2"><hr /></td></tr>
+                    <tr><td colspan="2"><div class="info-box"><strong>Action Properties</strong></div></td></tr>
 
             <tr>
                 <td>Action Type</td>
@@ -153,19 +178,19 @@ else
             <CheckBoxRow Property="vm.GetPropertyInfo<bool>(() => vm.Model.IsPassive)" />
             <TextAreaRow Property="vm.GetPropertyInfo<string?>(() => vm.Model.ActionDescription)" />
 
-            <!-- Combat-Specific Properties -->
-            @if (vm.Model.IsCombatSkill)
-            {
-                <tr><td colspan="2"><hr /></td></tr>
-                <tr><td colspan="2"><h4>Combat Properties</h4></td></tr>
-                <CheckBoxRow Property="vm.GetPropertyInfo<bool>(() => vm.Model.AppliesPhysicalityBonus)" />
-            }
+                    <!-- Combat-Specific Properties -->
+                    @if (vm.Model.IsCombatSkill)
+                    {
+                        <tr><td colspan="2"><hr /></td></tr>
+                        <tr><td colspan="2"><div class="info-box"><strong>Combat Properties</strong></div></td></tr>
+                        <CheckBoxRow Property="vm.GetPropertyInfo<bool>(() => vm.Model.AppliesPhysicalityBonus)" />
+                    }
 
-            <!-- Spell-Specific Properties -->
-            @if (vm.Model.IsActiveSpell)
-            {
-                <tr><td colspan="2"><hr /></td></tr>
-                <tr><td colspan="2"><h4>Spell Properties</h4></td></tr>
+                    <!-- Spell-Specific Properties -->
+                    @if (vm.Model.IsActiveSpell)
+                    {
+                        <tr><td colspan="2"><hr /></td></tr>
+                        <tr><td colspan="2"><div class="info-box card-header-purple"><strong>Spell Properties</strong></div></td></tr>
                 
                 <CheckBoxRow Property="vm.GetPropertyInfo<bool>(() => vm.Model.CanPumpWithFatigue)" />
                 <CheckBoxRow Property="vm.GetPropertyInfo<bool>(() => vm.Model.CanPumpWithMana)" />
@@ -182,24 +207,26 @@ else
                 </tr>
             }
 
-            <!-- Mana Skill Properties -->
-            @if (vm.Model.IsManaSkill)
-            {
-                <tr><td colspan="2"><hr /></td></tr>
-                <tr><td colspan="2"><h4>Mana Channeling Properties</h4></td></tr>
-                
-                <tr>
-                    <td colspan="2">
-                        <em>Mana channeling skills focus on gathering and storing mana for spell use.</em>
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
-    
-    <div class="mt-3">
-        <button type="button" @onclick="SaveData" class="btn btn-primary" disabled="@(!vm.Model.IsSavable)">Save</button>
-        <button type="button" @onclick="Cancel" class="btn btn-secondary ms-2">Cancel</button>
+                    <!-- Mana Skill Properties -->
+                    @if (vm.Model.IsManaSkill)
+                    {
+                        <tr><td colspan="2"><hr /></td></tr>
+                        <tr><td colspan="2"><div class="info-box text-mana"><strong>Mana Channeling Properties</strong></div></td></tr>
+
+                        <tr>
+                            <td colspan="2">
+                                <em class="item-description">Mana channeling skills focus on gathering and storing mana for spell use.</em>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+
+        <div class="card-footer">
+            <button type="button" @onclick="SaveData" class="btn btn-primary" disabled="@(!vm.Model.IsSavable)">Save</button>
+            <button type="button" @onclick="Cancel" class="btn btn-secondary ms-2">Cancel</button>
+        </div>
     </div>
 }
 

--- a/Threa/Threa.Client/Components/Pages/GameMaster/Skills.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/Skills.razor
@@ -10,40 +10,69 @@
 
 @attribute [Authorize(Roles = "GameMaster,Administrator")]
 
-<h3>Manage Skills</h3>
+<div class="info-box d-flex justify-content-between align-items-center">
+    <div>
+        <strong>Manage Skills</strong>
+        @if (skills != null)
+        {
+            <span class="item-meta ms-3">@skills.Count() skills defined</span>
+        }
+    </div>
+    <a href="/gamemaster/skills/new" class="btn btn-primary btn-sm">Add New Skill</a>
+</div>
 
-<div class="alert-danger">@vm.ViewModelErrorText</div>
+@if (!string.IsNullOrEmpty(vm.ViewModelErrorText))
+{
+    <div class="alert alert-danger">@vm.ViewModelErrorText</div>
+}
 
 @if (vm.Model == null)
 {
-    <div>Loading...</div>
-    <img src="images/busy.gif" class="busy-animation" />
+    <div class="card">
+        <div class="card-body text-center py-4">
+            <div class="item-meta mb-2">Loading skills...</div>
+            <img src="images/busy.gif" class="busy-animation" />
+        </div>
+    </div>
 }
 else
 {
-    <a href="/gamemaster/skills/new" class="btn btn-primary mb-3">Add New Skill</a>
-    
-    <QuickGrid Items="skills">
-        <PropertyColumn Title="Name" Property="@(p => p.Name)" Sortable="true" />
-        <PropertyColumn Title="Category" Property="@(p => p.Category)" Sortable="true" />
-        <PropertyColumn Title="Type" Property="@(p => GetSkillType(p))" />
-        <PropertyColumn Title="Primary Attribute" Property="@(p => p.PrimaryAttribute)" />
-        <PropertyColumn Title="Untrained XP" Property="@(p => p.Untrained)" />
-        <PropertyColumn Title="Trained XP" Property="@(p => p.Trained)" />
-        <TemplateColumn Title="Actions">
-            <a href="/gamemaster/skills/@context.Id">Edit</a>
-            @if (context.CanBeDeleted)
-            {
-                <text> | </text>
-                <a href="/gamemaster/skills/@context.Id/delete" class="btn btn-link btn-sm">Delete</a>
-            }
-            else
-            {
-                <text> | </text>
-                <span class="text-muted" title="Core attribute skills cannot be deleted">Delete</span>
-            }
-        </TemplateColumn>
-    </QuickGrid>
+    <div class="card">
+        <div class="card-body p-0">
+            <QuickGrid Items="skills" Class="table table-hover">
+                <PropertyColumn Title="Name" Property="@(p => p.Name)" Sortable="true" />
+                <PropertyColumn Title="Category" Property="@(p => p.Category)" Sortable="true" />
+                <TemplateColumn Title="Type">
+                    @{
+                        var skillType = GetSkillType(context);
+                        var badgeClass = skillType switch
+                        {
+                            "Magic" => "badge-purple",
+                            "Specialized" => "badge bg-info",
+                            _ => "badge bg-secondary"
+                        };
+                    }
+                    <span class="badge @badgeClass">@skillType</span>
+                </TemplateColumn>
+                <PropertyColumn Title="Primary Attr" Property="@(p => p.PrimaryAttribute)" />
+                <PropertyColumn Title="Untrained" Property="@(p => p.Untrained)" />
+                <PropertyColumn Title="Trained" Property="@(p => p.Trained)" />
+                <TemplateColumn Title="Actions">
+                    <a href="/gamemaster/skills/@context.Id">Edit</a>
+                    @if (context.CanBeDeleted)
+                    {
+                        <text> | </text>
+                        <a href="/gamemaster/skills/@context.Id/delete" class="text-negative">Delete</a>
+                    }
+                    else
+                    {
+                        <text> | </text>
+                        <span class="text-neutral" title="Core attribute skills cannot be deleted">Delete</span>
+                    }
+                </TemplateColumn>
+            </QuickGrid>
+        </div>
+    </div>
 }
 
 @code {

--- a/Threa/Threa.Client/Components/Pages/GameMaster/Species.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/Species.razor
@@ -9,56 +9,80 @@
 
 @attribute [Authorize(Roles = "GameMaster,Administrator")]
 
-<h3>Manage Species</h3>
+<div class="info-box d-flex justify-content-between align-items-center">
+    <div>
+        <strong>Manage Species</strong>
+        @if (species != null)
+        {
+            <span class="item-meta ms-3">@species.Count() species defined</span>
+        }
+    </div>
+    <a href="/gamemaster/species/new" class="btn btn-primary btn-sm">Add New Species</a>
+</div>
 
-<div class="alert-danger">@vm.ViewModelErrorText</div>
+@if (!string.IsNullOrEmpty(vm.ViewModelErrorText))
+{
+    <div class="alert alert-danger">@vm.ViewModelErrorText</div>
+}
 
 @if (vm.Model == null)
 {
-    <div>Loading...</div>
-    <img src="images/busy.gif" class="busy-animation" />
+    <div class="card">
+        <div class="card-body text-center py-4">
+            <div class="item-meta mb-2">Loading species...</div>
+            <img src="images/busy.gif" class="busy-animation" />
+        </div>
+    </div>
 }
 else
 {
-    <a href="/gamemaster/species/new" class="btn btn-primary mb-3">Add New Species</a>
-    
-    <QuickGrid Items="species">
-        <PropertyColumn Title="Name" Property="@(p => p.Name)" Sortable="true" />
-        <PropertyColumn Title="Description" Property="@(p => p.Description)" />
-        <TemplateColumn Title="Attribute Modifiers">
-            @if (context.AttributeModifiers.Any())
-            {
-                @string.Join(", ", context.AttributeModifiers.Select(m => $"{m.AttributeName} {(m.Modifier >= 0 ? "+" : "")}{m.Modifier}"))
-            }
-            else
-            {
-                <span class="text-muted">None</span>
-            }
-        </TemplateColumn>
-        <TemplateColumn Title="Type">
-            @if (context.Id.Equals("Human", StringComparison.OrdinalIgnoreCase))
-            {
-                <span class="badge bg-primary">Baseline</span>
-            }
-            else
-            {
-                <span class="badge bg-secondary">Custom</span>
-            }
-        </TemplateColumn>
-        <TemplateColumn Title="Actions">
-            <a href="/gamemaster/species/@context.Id">Edit</a>
-            @if (context.CanBeDeleted)
-            {
-                <text> | </text>
-                <a href="/gamemaster/species/@context.Id/delete" class="btn btn-link btn-sm">Delete</a>
-            }
-            else
-            {
-                <text> | </text>
-                <span class="text-muted" title="Human is the baseline species and cannot be deleted">Delete</span>
-            }
-        </TemplateColumn>
-    </QuickGrid>
+    <div class="card">
+        <div class="card-body p-0">
+            <QuickGrid Items="species" Class="table table-hover">
+                <PropertyColumn Title="Name" Property="@(p => p.Name)" Sortable="true" />
+                <PropertyColumn Title="Description" Property="@(p => p.Description)" />
+                <TemplateColumn Title="Attribute Modifiers">
+                    @if (context.AttributeModifiers.Any())
+                    {
+                        <div class="d-flex flex-wrap gap-1">
+                            @foreach (var mod in context.AttributeModifiers)
+                            {
+                                var colorClass = mod.Modifier > 0 ? "text-positive" : (mod.Modifier < 0 ? "text-negative" : "text-neutral");
+                                <span class="@colorClass">@mod.AttributeName @(mod.Modifier >= 0 ? "+" : "")@mod.Modifier</span>
+                            }
+                        </div>
+                    }
+                    else
+                    {
+                        <span class="text-neutral">None (baseline)</span>
+                    }
+                </TemplateColumn>
+                <TemplateColumn Title="Type">
+                    @if (context.Id.Equals("Human", StringComparison.OrdinalIgnoreCase))
+                    {
+                        <span class="badge bg-primary">Baseline</span>
+                    }
+                    else
+                    {
+                        <span class="badge bg-secondary">Custom</span>
+                    }
+                </TemplateColumn>
+                <TemplateColumn Title="Actions">
+                    <a href="/gamemaster/species/@context.Id">Edit</a>
+                    @if (context.CanBeDeleted)
+                    {
+                        <text> | </text>
+                        <a href="/gamemaster/species/@context.Id/delete" class="text-negative">Delete</a>
+                    }
+                    else
+                    {
+                        <text> | </text>
+                        <span class="text-neutral" title="Human is the baseline species and cannot be deleted">Delete</span>
+                    }
+                </TemplateColumn>
+            </QuickGrid>
+        </div>
+    </div>
 }
 
 @code {

--- a/Threa/Threa.Client/Components/Pages/GameMaster/SpeciesEdit.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/SpeciesEdit.razor
@@ -12,22 +12,40 @@
 @inject Threa.Services.RenderModeProvider RenderModeProvider
 @inject NavigationManager NavigationManager
 
-<h3>@(IsNewSpecies ? "Add New Species" : "Edit Species")</h3>
+<div class="info-box d-flex justify-content-between align-items-center">
+    <div>
+        <strong>@(IsNewSpecies ? "Add New Species" : $"Edit: {vm.Model?.Name ?? "Species"}")</strong>
+        @if (vm.Model != null && !vm.Model.CanBeDeleted)
+        {
+            <span class="badge bg-primary ms-2">Baseline</span>
+        }
+    </div>
+    <a href="/gamemaster/species" class="btn btn-outline-secondary btn-sm">Back to Species</a>
+</div>
 
-<div class="alert-danger">@vm.ViewModelErrorText</div>
+@if (!string.IsNullOrEmpty(vm.ViewModelErrorText))
+{
+    <div class="alert alert-danger">@vm.ViewModelErrorText</div>
+}
 
 @if (vm.Model == null)
 {
-    <p>Loading...</p>
+    <div class="card">
+        <div class="card-body text-center py-4">
+            <div class="item-meta">Loading species...</div>
+        </div>
+    </div>
 }
 else
 {
-    <table>
-        <thead>
-            <tr><th></th><th></th></tr>
-        </thead>
-        <tbody>
-            <tr><td colspan="2"><h4>Basic Information</h4></td></tr>
+    <div class="card">
+        <div class="card-body">
+            <table class="table table-sm">
+                <thead>
+                    <tr><th></th><th></th></tr>
+                </thead>
+                <tbody>
+                    <tr><td colspan="2"><div class="info-box"><strong>Basic Information</strong></div></td></tr>
             
             @if (IsNewSpecies)
             {
@@ -50,8 +68,8 @@ else
             <TextInputRow Property="vm.GetPropertyInfo<string>(() => vm.Model.Name)" />
             <TextAreaRow Property="vm.GetPropertyInfo<string>(() => vm.Model.Description)" />
 
-            <tr><td colspan="2"><hr /></td></tr>
-            <tr><td colspan="2"><h4>Attribute Modifiers</h4></td></tr>
+                    <tr><td colspan="2"><hr /></td></tr>
+                    <tr><td colspan="2"><div class="info-box"><strong>Attribute Modifiers</strong></div></td></tr>
 
             <tr><td colspan="2">
                 <div class="alert alert-info">
@@ -69,24 +87,26 @@ else
             <NumericSelectorRow Property="vm.GetPropertyInfo<int>(() => vm.Model.WilModifier)" />
             <NumericSelectorRow Property="vm.GetPropertyInfo<int>(() => vm.Model.PhyModifier)" />
 
-            <tr><td colspan="2"><hr /></td></tr>
-            <tr><td colspan="2">
-                <div class="alert alert-secondary">
-                    <strong>Common Patterns:</strong>
-                    <ul class="mb-0">
-                        <li><strong>Elves:</strong> +DEX, +ITT, -END (agile, perceptive, delicate)</li>
-                        <li><strong>Dwarves:</strong> +END, +STR, -DEX (hardy, strong, less agile)</li>
-                        <li><strong>Halflings:</strong> +DEX, +ITT, -STR (nimble, aware, small)</li>
-                        <li><strong>Orcs:</strong> +STR, +END, -INT (powerful, tough, less educated)</li>
-                    </ul>
-                </div>
-            </td></tr>
-        </tbody>
-    </table>
-    
-    <div class="mt-3">
-        <button type="button" @onclick="SaveData" class="btn btn-primary" disabled="@(!vm.Model.IsSavable)">Save</button>
-        <button type="button" @onclick="Cancel" class="btn btn-secondary ms-2">Cancel</button>
+                    <tr><td colspan="2"><hr /></td></tr>
+                    <tr><td colspan="2">
+                        <div class="alert alert-secondary">
+                            <strong>Common Patterns:</strong>
+                            <ul class="mb-0">
+                                <li><strong>Elves:</strong> <span class="text-positive">+DEX, +ITT</span>, <span class="text-negative">-END</span> (agile, perceptive, delicate)</li>
+                                <li><strong>Dwarves:</strong> <span class="text-positive">+END, +STR</span>, <span class="text-negative">-DEX</span> (hardy, strong, less agile)</li>
+                                <li><strong>Halflings:</strong> <span class="text-positive">+DEX, +ITT</span>, <span class="text-negative">-STR</span> (nimble, aware, small)</li>
+                                <li><strong>Orcs:</strong> <span class="text-positive">+STR, +END</span>, <span class="text-negative">-INT</span> (powerful, tough, less educated)</li>
+                            </ul>
+                        </div>
+                    </td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="card-footer">
+            <button type="button" @onclick="SaveData" class="btn btn-primary" disabled="@(!vm.Model.IsSavable)">Save</button>
+            <button type="button" @onclick="Cancel" class="btn btn-secondary ms-2">Cancel</button>
+        </div>
     </div>
 }
 


### PR DESCRIPTION
## Summary

- Apply consistent fantasy theme styling to all Game Master pages for managing static data
- Update Items, Skills, Magic Schools, and Species list and edit pages
- Improve readability and visual consistency with player-facing pages

## Changes

### List Pages (Items, Skills, MagicSchools, Species)
- Add `.info-box` headers with entity counts and "Add New" buttons
- Wrap data grids in themed `.card` components
- Use semantic color classes for status indicators (`.text-positive`, `.text-negative`)
- Improve badge styling for type/status columns
- Better loading state presentation with centered loading indicators

### Edit Pages (ItemEdit, SkillEdit, MagicSchoolEdit, SpeciesEdit)
- Add styled headers with back navigation buttons
- Use `.info-box` for section headers instead of plain `<h4>` elements
- Wrap forms in `.card` with `.card-body` and `.card-footer`
- Use semantic color classes for helper text
- Add status badges in page headers

## Test plan

- [ ] Visit /gamemaster/items - verify styled list with filters
- [ ] Edit an item - verify styled edit form with section headers
- [ ] Visit /gamemaster/skills - verify styled list with type badges
- [ ] Edit a skill - verify styled edit form with section headers
- [ ] Visit /gamemaster/magicschools - verify styled list with color display
- [ ] Edit a magic school - verify styled edit form with purple headers
- [ ] Visit /gamemaster/species - verify styled list with modifier colors
- [ ] Edit a species - verify styled edit form with modifier examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)