### PR TITLE
Add item effects editor to GM item management

### DIFF
--- a/GameMechanics.Test/ItemEffectEditTests.cs
+++ b/GameMechanics.Test/ItemEffectEditTests.cs
@@ -1,0 +1,443 @@
+using Csla;
+using GameMechanics.Items;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using System.Threading.Tasks;
+using Threa.Dal.Dto;
+
+namespace GameMechanics.Test;
+
+[TestClass]
+public class ItemEffectEditTests : TestBase
+{
+    #region ItemEffectEdit Child Object Tests
+
+    [TestMethod]
+    public async Task ItemEffectEdit_Create_InitializesDefaults()
+    {
+        // Arrange
+        var provider = InitServices();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        // Act
+        var effect = effectPortal.CreateChild(0);
+
+        // Assert
+        Assert.AreEqual(0, effect.Id, "Id should be 0 for new effect");
+        Assert.AreEqual(0, effect.ItemTemplateId, "ItemTemplateId should match the passed value");
+        Assert.AreEqual(string.Empty, effect.Name, "Name should be empty string");
+        Assert.AreEqual(EffectType.ItemEffect, effect.EffectType, "EffectType should default to ItemEffect");
+        Assert.AreEqual(ItemEffectTrigger.WhileEquipped, effect.Trigger, "Trigger should default to WhileEquipped");
+        Assert.IsFalse(effect.IsCursed, "IsCursed should default to false");
+        Assert.IsFalse(effect.RequiresAttunement, "RequiresAttunement should default to false");
+        Assert.IsNull(effect.DurationRounds, "DurationRounds should be null");
+        Assert.IsTrue(string.IsNullOrEmpty(effect.BehaviorState), "BehaviorState should be null or empty");
+        Assert.IsTrue(effect.IsActive, "IsActive should default to true");
+        Assert.AreEqual(0, effect.Priority, "Priority should default to 0");
+    }
+
+    [TestMethod]
+    public async Task ItemEffectEdit_Fetch_LoadsFromDto()
+    {
+        // Arrange
+        var provider = InitServices();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        var dto = new ItemEffectDefinition
+        {
+            Id = 42,
+            ItemTemplateId = 10,
+            EffectType = EffectType.Buff,
+            Name = "Strength Boost",
+            Description = "Grants +3 STR",
+            Trigger = ItemEffectTrigger.WhileEquipped,
+            IsCursed = false,
+            RequiresAttunement = true,
+            DurationRounds = null,
+            BehaviorState = "{\"Modifiers\":[{\"Type\":0,\"Target\":\"STR\",\"Value\":3}]}",
+            IconName = "shield",
+            IsActive = true,
+            Priority = 5
+        };
+
+        // Act
+        var effect = effectPortal.FetchChild(dto);
+
+        // Assert
+        Assert.AreEqual(42, effect.Id, "Id should be loaded from DTO");
+        Assert.AreEqual(10, effect.ItemTemplateId, "ItemTemplateId should be loaded from DTO");
+        Assert.AreEqual(EffectType.Buff, effect.EffectType, "EffectType should be loaded from DTO");
+        Assert.AreEqual("Strength Boost", effect.Name, "Name should be loaded from DTO");
+        Assert.AreEqual("Grants +3 STR", effect.Description, "Description should be loaded from DTO");
+        Assert.AreEqual(ItemEffectTrigger.WhileEquipped, effect.Trigger, "Trigger should be loaded from DTO");
+        Assert.IsFalse(effect.IsCursed, "IsCursed should be loaded from DTO");
+        Assert.IsTrue(effect.RequiresAttunement, "RequiresAttunement should be loaded from DTO");
+        Assert.IsNull(effect.DurationRounds, "DurationRounds should be loaded from DTO");
+        Assert.IsNotNull(effect.BehaviorState, "BehaviorState should be loaded from DTO");
+        Assert.AreEqual("shield", effect.IconName, "IconName should be loaded from DTO");
+        Assert.IsTrue(effect.IsActive, "IsActive should be loaded from DTO");
+        Assert.AreEqual(5, effect.Priority, "Priority should be loaded from DTO");
+    }
+
+    [TestMethod]
+    public async Task ItemEffectEdit_Validation_NameRequired()
+    {
+        // Arrange
+        var provider = InitServices();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        // Act - Create effect with empty name (default)
+        var effect = effectPortal.CreateChild(0);
+        // Leave name empty, but set a valid trigger
+        effect.Trigger = ItemEffectTrigger.WhileEquipped;
+
+        // Assert
+        Assert.IsFalse(effect.IsValid, "Effect with empty Name should not be valid");
+        Assert.IsTrue(effect.BrokenRulesCollection.Any(r => r.Property == "Name"),
+            "BrokenRulesCollection should contain Name rule violation");
+    }
+
+    [TestMethod]
+    public async Task ItemEffectEdit_Validation_TriggerRequired()
+    {
+        // Arrange
+        var provider = InitServices();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        // Act - Create effect with Trigger = None
+        var effect = effectPortal.CreateChild(0);
+        effect.Name = "Test Effect";
+        effect.Trigger = ItemEffectTrigger.None;
+
+        // Assert
+        Assert.IsFalse(effect.IsValid, "Effect with Trigger=None should not be valid");
+        Assert.IsTrue(effect.BrokenRulesCollection.Any(r => r.Property == "Trigger"),
+            "BrokenRulesCollection should contain Trigger rule violation");
+    }
+
+    [TestMethod]
+    public async Task ItemEffectEdit_Validation_ValidEffectIsValid()
+    {
+        // Arrange
+        var provider = InitServices();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        // Act - Create valid effect
+        var effect = effectPortal.CreateChild(0);
+        effect.Name = "Valid Effect";
+        effect.Trigger = ItemEffectTrigger.WhileEquipped;
+
+        // Assert
+        Assert.IsTrue(effect.IsValid, "Effect with Name and valid Trigger should be valid");
+        Assert.AreEqual(0, effect.BrokenRulesCollection.ErrorCount,
+            "Effect should have no errors");
+    }
+
+    [TestMethod]
+    public async Task ItemEffectEdit_AllPropertiesSettable()
+    {
+        // Arrange
+        var provider = InitServices();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        // Act
+        var effect = effectPortal.CreateChild(10);
+        effect.Name = "Life Drain";
+        effect.Description = "Drains health over time";
+        effect.EffectType = EffectType.Debuff;
+        effect.Trigger = ItemEffectTrigger.WhilePossessed;
+        effect.IsCursed = true;
+        effect.RequiresAttunement = false;
+        effect.DurationRounds = 10;
+        effect.BehaviorState = "{\"test\":\"data\"}";
+        effect.IconName = "skull";
+        effect.IsActive = true;
+        effect.Priority = 3;
+
+        // Assert - all properties can be read back
+        Assert.AreEqual("Life Drain", effect.Name, "Name should be settable");
+        Assert.AreEqual("Drains health over time", effect.Description, "Description should be settable");
+        Assert.AreEqual(EffectType.Debuff, effect.EffectType, "EffectType should be settable");
+        Assert.AreEqual(ItemEffectTrigger.WhilePossessed, effect.Trigger, "Trigger should be settable");
+        Assert.IsTrue(effect.IsCursed, "IsCursed should be settable");
+        Assert.IsFalse(effect.RequiresAttunement, "RequiresAttunement should be settable");
+        Assert.AreEqual(10, effect.DurationRounds, "DurationRounds should be settable");
+        Assert.AreEqual("{\"test\":\"data\"}", effect.BehaviorState, "BehaviorState should be settable");
+        Assert.AreEqual("skull", effect.IconName, "IconName should be settable");
+        Assert.IsTrue(effect.IsActive, "IsActive should be settable");
+        Assert.AreEqual(3, effect.Priority, "Priority should be settable");
+    }
+
+    #endregion
+
+    #region ItemEffectEditList Tests
+
+    [TestMethod]
+    public async Task ItemEffectEditList_Create_IsEmpty()
+    {
+        // Arrange
+        var provider = InitServices();
+        var listPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEditList>>();
+
+        // Act
+        var list = listPortal.CreateChild();
+
+        // Assert
+        Assert.AreEqual(0, list.Count, "New list should be empty");
+    }
+
+    [TestMethod]
+    public async Task ItemEffectEditList_Fetch_LoadsEffects()
+    {
+        // Arrange
+        var provider = InitServices();
+        var listPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEditList>>();
+
+        var effects = new System.Collections.Generic.List<ItemEffectDefinition>
+        {
+            new() { Id = 1, Name = "Effect 1", Trigger = ItemEffectTrigger.WhileEquipped },
+            new() { Id = 2, Name = "Effect 2", Trigger = ItemEffectTrigger.OnUse }
+        };
+
+        // Act
+        var list = listPortal.FetchChild(effects);
+
+        // Assert
+        Assert.AreEqual(2, list.Count, "List should contain 2 effects");
+        Assert.AreEqual("Effect 1", list[0].Name, "First effect name should match");
+        Assert.AreEqual("Effect 2", list[1].Name, "Second effect name should match");
+    }
+
+    [TestMethod]
+    public async Task ItemEffectEditList_AddNewEffect_AddsToList()
+    {
+        // Arrange
+        var provider = InitServices();
+        var listPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEditList>>();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        var list = listPortal.CreateChild();
+
+        // Act
+        var newEffect = list.AddNewEffect(10, effectPortal);
+
+        // Assert
+        Assert.AreEqual(1, list.Count, "List should contain 1 effect");
+        Assert.AreSame(newEffect, list[0], "The returned effect should be in the list");
+        Assert.AreEqual(10, newEffect.ItemTemplateId, "Effect should have the correct ItemTemplateId");
+    }
+
+    [TestMethod]
+    public async Task ItemEffectEditList_GetByTrigger_FiltersCorrectly()
+    {
+        // Arrange
+        var provider = InitServices();
+        var listPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEditList>>();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        var list = listPortal.CreateChild();
+        var effect1 = list.AddNewEffect(10, effectPortal);
+        effect1.Name = "Effect A";
+        effect1.Trigger = ItemEffectTrigger.WhileEquipped;
+
+        var effect2 = list.AddNewEffect(10, effectPortal);
+        effect2.Name = "Effect B";
+        effect2.Trigger = ItemEffectTrigger.OnUse;
+
+        var effect3 = list.AddNewEffect(10, effectPortal);
+        effect3.Name = "Effect C";
+        effect3.Trigger = ItemEffectTrigger.WhileEquipped;
+
+        // Act
+        var equippedEffects = list.GetByTrigger(ItemEffectTrigger.WhileEquipped).ToList();
+        var onUseEffects = list.GetByTrigger(ItemEffectTrigger.OnUse).ToList();
+
+        // Assert
+        Assert.AreEqual(2, equippedEffects.Count, "Should have 2 WhileEquipped effects");
+        Assert.AreEqual(1, onUseEffects.Count, "Should have 1 OnUse effect");
+        Assert.IsTrue(equippedEffects.All(e => e.Trigger == ItemEffectTrigger.WhileEquipped),
+            "All filtered effects should have WhileEquipped trigger");
+    }
+
+    #endregion
+
+    #region Integration Tests with ItemTemplateEdit
+
+    [TestMethod]
+    public async Task ItemTemplateEdit_Create_HasEmptyEffectsList()
+    {
+        // Arrange
+        var provider = InitServices();
+        var dp = provider.GetRequiredService<IDataPortal<ItemTemplateEdit>>();
+
+        // Act
+        var template = await dp.CreateAsync();
+
+        // Assert
+        Assert.IsNotNull(template.Effects, "Effects collection should not be null");
+        Assert.AreEqual(0, template.Effects.Count, "New template should have empty effects list");
+    }
+
+    [TestMethod]
+    public async Task ItemTemplateEdit_SaveAndFetch_EffectsPersist()
+    {
+        // Arrange
+        var provider = InitServices();
+        var dp = provider.GetRequiredService<IDataPortal<ItemTemplateEdit>>();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        // Create a new template with an effect
+        var template = await dp.CreateAsync();
+        template.Name = "Magic Ring";
+        template.ItemType = ItemType.Jewelry;
+        template.EquipmentSlot = EquipmentSlot.FingerLeft1;
+
+        var effect = template.Effects.AddNewEffect(template.Id, effectPortal);
+        effect.Name = "Strength Boost";
+        effect.Description = "Grants +3 STR while worn";
+        effect.EffectType = EffectType.Buff;
+        effect.Trigger = ItemEffectTrigger.WhileEquipped;
+        effect.IsCursed = false;
+
+        // Act - Save
+        template = await template.SaveAsync();
+        var savedId = template.Id;
+        Assert.IsTrue(savedId > 0, "Saved template should have an Id > 0");
+
+        // Fetch the saved template
+        var loaded = await dp.FetchAsync(savedId);
+
+        // Assert
+        Assert.IsNotNull(loaded.Effects, "Loaded template should have Effects collection");
+        Assert.AreEqual(1, loaded.Effects.Count, "Loaded template should have 1 effect");
+
+        var loadedEffect = loaded.Effects[0];
+        Assert.AreEqual("Strength Boost", loadedEffect.Name, "Effect name should persist");
+        Assert.AreEqual("Grants +3 STR while worn", loadedEffect.Description, "Effect description should persist");
+        Assert.AreEqual(EffectType.Buff, loadedEffect.EffectType, "Effect type should persist");
+        Assert.AreEqual(ItemEffectTrigger.WhileEquipped, loadedEffect.Trigger, "Effect trigger should persist");
+        Assert.IsFalse(loadedEffect.IsCursed, "Effect IsCursed should persist");
+    }
+
+    [TestMethod]
+    public async Task ItemTemplateEdit_UpdateEffects_ChangesPersist()
+    {
+        // Arrange
+        var provider = InitServices();
+        var dp = provider.GetRequiredService<IDataPortal<ItemTemplateEdit>>();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        // Create a new template with an effect
+        var template = await dp.CreateAsync();
+        template.Name = "Cursed Amulet";
+        template.ItemType = ItemType.Jewelry;
+        template.EquipmentSlot = EquipmentSlot.Neck;
+
+        var effect = template.Effects.AddNewEffect(template.Id, effectPortal);
+        effect.Name = "Minor Curse";
+        effect.Trigger = ItemEffectTrigger.WhilePossessed;
+
+        // Save first version
+        template = await template.SaveAsync();
+        var savedId = template.Id;
+
+        // Fetch, modify effect, and save again
+        template = await dp.FetchAsync(savedId);
+        template.Effects[0].Name = "Major Curse";
+        template.Effects[0].IsCursed = true;
+        template = await template.SaveAsync();
+
+        // Fetch and verify changes
+        var loaded = await dp.FetchAsync(savedId);
+
+        // Assert
+        Assert.AreEqual(1, loaded.Effects.Count, "Should still have 1 effect");
+        Assert.AreEqual("Major Curse", loaded.Effects[0].Name, "Updated effect name should persist");
+        Assert.IsTrue(loaded.Effects[0].IsCursed, "Updated IsCursed should persist");
+    }
+
+    [TestMethod]
+    public async Task ItemTemplateEdit_AddMultipleEffects_AllPersist()
+    {
+        // Arrange
+        var provider = InitServices();
+        var dp = provider.GetRequiredService<IDataPortal<ItemTemplateEdit>>();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        // Create a new template with multiple effects
+        var template = await dp.CreateAsync();
+        template.Name = "Legendary Sword";
+        template.ItemType = ItemType.Weapon;
+        template.EquipmentSlot = EquipmentSlot.MainHand;
+
+        var effect1 = template.Effects.AddNewEffect(template.Id, effectPortal);
+        effect1.Name = "Fire Damage";
+        effect1.Trigger = ItemEffectTrigger.OnAttackWith;
+
+        var effect2 = template.Effects.AddNewEffect(template.Id, effectPortal);
+        effect2.Name = "Strength Bonus";
+        effect2.Trigger = ItemEffectTrigger.WhileEquipped;
+
+        var effect3 = template.Effects.AddNewEffect(template.Id, effectPortal);
+        effect3.Name = "Curse of Bloodlust";
+        effect3.Trigger = ItemEffectTrigger.OnPickup;
+        effect3.IsCursed = true;
+
+        // Act - Save
+        template = await template.SaveAsync();
+        var savedId = template.Id;
+
+        // Fetch
+        var loaded = await dp.FetchAsync(savedId);
+
+        // Assert
+        Assert.AreEqual(3, loaded.Effects.Count, "Should have 3 effects");
+        Assert.IsTrue(loaded.Effects.Any(e => e.Name == "Fire Damage"), "Fire Damage effect should persist");
+        Assert.IsTrue(loaded.Effects.Any(e => e.Name == "Strength Bonus"), "Strength Bonus effect should persist");
+        Assert.IsTrue(loaded.Effects.Any(e => e.Name == "Curse of Bloodlust" && e.IsCursed),
+            "Cursed effect should persist with IsCursed=true");
+    }
+
+    [TestMethod]
+    public async Task ItemTemplateEdit_RemoveEffect_Persists()
+    {
+        // Arrange
+        var provider = InitServices();
+        var dp = provider.GetRequiredService<IDataPortal<ItemTemplateEdit>>();
+        var effectPortal = provider.GetRequiredService<IChildDataPortal<ItemEffectEdit>>();
+
+        // Create template with two effects
+        var template = await dp.CreateAsync();
+        template.Name = "Test Item";
+        template.ItemType = ItemType.Weapon;
+
+        var effect1 = template.Effects.AddNewEffect(template.Id, effectPortal);
+        effect1.Name = "Effect 1";
+        effect1.Trigger = ItemEffectTrigger.WhileEquipped;
+
+        var effect2 = template.Effects.AddNewEffect(template.Id, effectPortal);
+        effect2.Name = "Effect 2";
+        effect2.Trigger = ItemEffectTrigger.OnUse;
+
+        template = await template.SaveAsync();
+        var savedId = template.Id;
+
+        // Fetch, remove one effect, and save
+        template = await dp.FetchAsync(savedId);
+        Assert.AreEqual(2, template.Effects.Count, "Should have 2 effects before removal");
+
+        var effectToRemove = template.Effects.First(e => e.Name == "Effect 1");
+        template.Effects.Remove(effectToRemove);
+        template = await template.SaveAsync();
+
+        // Fetch and verify
+        var loaded = await dp.FetchAsync(savedId);
+
+        // Assert
+        Assert.AreEqual(1, loaded.Effects.Count, "Should have 1 effect after removal");
+        Assert.AreEqual("Effect 2", loaded.Effects[0].Name, "Remaining effect should be Effect 2");
+    }
+
+    #endregion
+}

--- a/GameMechanics/Items/ItemEffectEdit.cs
+++ b/GameMechanics/Items/ItemEffectEdit.cs
@@ -1,0 +1,285 @@
+using System;
+using Csla;
+using Csla.Core;
+using Csla.Rules;
+using Csla.Rules.CommonRules;
+using Threa.Dal.Dto;
+
+namespace GameMechanics.Items;
+
+/// <summary>
+/// Editable child business object for an item effect definition.
+/// These effects are applied to characters when items are equipped, possessed, or used.
+/// </summary>
+[Serializable]
+public class ItemEffectEdit : BusinessBase<ItemEffectEdit>
+{
+    public static readonly PropertyInfo<int> IdProperty = RegisterProperty<int>(nameof(Id));
+    public int Id
+    {
+        get => GetProperty(IdProperty);
+        private set => LoadProperty(IdProperty, value);
+    }
+
+    public static readonly PropertyInfo<int> ItemTemplateIdProperty = RegisterProperty<int>(nameof(ItemTemplateId));
+    public int ItemTemplateId
+    {
+        get => GetProperty(ItemTemplateIdProperty);
+        private set => LoadProperty(ItemTemplateIdProperty, value);
+    }
+
+    public static readonly PropertyInfo<int?> EffectDefinitionIdProperty = RegisterProperty<int?>(nameof(EffectDefinitionId));
+    public int? EffectDefinitionId
+    {
+        get => GetProperty(EffectDefinitionIdProperty);
+        set => SetProperty(EffectDefinitionIdProperty, value);
+    }
+
+    public static readonly PropertyInfo<EffectType> EffectTypeProperty = RegisterProperty<EffectType>(nameof(EffectType));
+    public EffectType EffectType
+    {
+        get => GetProperty(EffectTypeProperty);
+        set => SetProperty(EffectTypeProperty, value);
+    }
+
+    public static readonly PropertyInfo<string> NameProperty = RegisterProperty<string>(nameof(Name));
+    public string Name
+    {
+        get => GetProperty(NameProperty);
+        set => SetProperty(NameProperty, value);
+    }
+
+    public static readonly PropertyInfo<string?> DescriptionProperty = RegisterProperty<string?>(nameof(Description));
+    public string? Description
+    {
+        get => GetProperty(DescriptionProperty);
+        set => SetProperty(DescriptionProperty, value);
+    }
+
+    public static readonly PropertyInfo<ItemEffectTrigger> TriggerProperty = RegisterProperty<ItemEffectTrigger>(nameof(Trigger));
+    public ItemEffectTrigger Trigger
+    {
+        get => GetProperty(TriggerProperty);
+        set => SetProperty(TriggerProperty, value);
+    }
+
+    public static readonly PropertyInfo<bool> IsCursedProperty = RegisterProperty<bool>(nameof(IsCursed));
+    public bool IsCursed
+    {
+        get => GetProperty(IsCursedProperty);
+        set => SetProperty(IsCursedProperty, value);
+    }
+
+    public static readonly PropertyInfo<bool> RequiresAttunementProperty = RegisterProperty<bool>(nameof(RequiresAttunement));
+    public bool RequiresAttunement
+    {
+        get => GetProperty(RequiresAttunementProperty);
+        set => SetProperty(RequiresAttunementProperty, value);
+    }
+
+    public static readonly PropertyInfo<int?> DurationRoundsProperty = RegisterProperty<int?>(nameof(DurationRounds));
+    public int? DurationRounds
+    {
+        get => GetProperty(DurationRoundsProperty);
+        set => SetProperty(DurationRoundsProperty, value);
+    }
+
+    public static readonly PropertyInfo<string?> BehaviorStateProperty = RegisterProperty<string?>(nameof(BehaviorState));
+    public string? BehaviorState
+    {
+        get => GetProperty(BehaviorStateProperty);
+        set => SetProperty(BehaviorStateProperty, value);
+    }
+
+    public static readonly PropertyInfo<string?> IconNameProperty = RegisterProperty<string?>(nameof(IconName));
+    public string? IconName
+    {
+        get => GetProperty(IconNameProperty);
+        set => SetProperty(IconNameProperty, value);
+    }
+
+    public static readonly PropertyInfo<bool> IsActiveProperty = RegisterProperty<bool>(nameof(IsActive));
+    public bool IsActive
+    {
+        get => GetProperty(IsActiveProperty);
+        set => SetProperty(IsActiveProperty, value);
+    }
+
+    public static readonly PropertyInfo<int> PriorityProperty = RegisterProperty<int>(nameof(Priority));
+    public int Priority
+    {
+        get => GetProperty(PriorityProperty);
+        set => SetProperty(PriorityProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the display name for the trigger type.
+    /// </summary>
+    public string TriggerDisplayName => GetTriggerDisplayName(Trigger);
+
+    /// <summary>
+    /// Gets a summary of the effect for display in lists.
+    /// </summary>
+    public string EffectSummary => BuildEffectSummary();
+
+    protected override void AddBusinessRules()
+    {
+        base.AddBusinessRules();
+
+        BusinessRules.AddRule(new Required(NameProperty) { MessageText = "Effect name is required." });
+        BusinessRules.AddRule(new TriggerRequiredRule(TriggerProperty));
+    }
+
+    private string BuildEffectSummary()
+    {
+        var parts = new System.Collections.Generic.List<string>();
+
+        if (IsCursed)
+            parts.Add("Cursed");
+
+        if (RequiresAttunement)
+            parts.Add("Attunement");
+
+        if (DurationRounds.HasValue)
+            parts.Add($"{DurationRounds} rounds");
+
+        if (!string.IsNullOrEmpty(Description))
+            parts.Add(Description);
+
+        return parts.Count > 0 ? string.Join(" | ", parts) : EffectType.ToString();
+    }
+
+    private static string GetTriggerDisplayName(ItemEffectTrigger trigger) => trigger switch
+    {
+        ItemEffectTrigger.None => "None",
+        ItemEffectTrigger.WhileEquipped => "While Equipped",
+        ItemEffectTrigger.WhilePossessed => "While Possessed",
+        ItemEffectTrigger.OnUse => "On Use",
+        ItemEffectTrigger.OnAttackWith => "On Attack With",
+        ItemEffectTrigger.OnHitWhileWearing => "On Hit While Wearing",
+        ItemEffectTrigger.OnCritical => "On Critical",
+        ItemEffectTrigger.OnPickup => "On Pickup",
+        _ => trigger.ToString()
+    };
+
+    /// <summary>
+    /// Gets a description of what the trigger does.
+    /// </summary>
+    public static string GetTriggerDescription(ItemEffectTrigger trigger) => trigger switch
+    {
+        ItemEffectTrigger.None => "Not from an item",
+        ItemEffectTrigger.WhileEquipped => "Active while the item is equipped in a slot",
+        ItemEffectTrigger.WhilePossessed => "Active while the item is in inventory (equipped or not)",
+        ItemEffectTrigger.OnUse => "Applied when the item is used (consumables)",
+        ItemEffectTrigger.OnAttackWith => "Applied when attacking with this weapon",
+        ItemEffectTrigger.OnHitWhileWearing => "Applied when hit while wearing this item",
+        ItemEffectTrigger.OnCritical => "Applied on critical hit with this weapon",
+        ItemEffectTrigger.OnPickup => "Applied once when the item is first acquired",
+        _ => string.Empty
+    };
+
+    /// <summary>
+    /// Gets a description of how a curse blocks item actions for this trigger type.
+    /// </summary>
+    public static string GetCurseBlockingDescription(ItemEffectTrigger trigger) => trigger switch
+    {
+        ItemEffectTrigger.WhileEquipped => "Character cannot unequip this item until the curse is removed",
+        ItemEffectTrigger.WhilePossessed or ItemEffectTrigger.OnPickup =>
+            "Character cannot drop or transfer this item until the curse is removed",
+        _ => "This effect cannot be removed normally"
+    };
+
+    [CreateChild]
+    private void Create(int itemTemplateId)
+    {
+        using (BypassPropertyChecks)
+        {
+            Id = 0;
+            ItemTemplateId = itemTemplateId;
+            EffectDefinitionId = null;
+            EffectType = EffectType.ItemEffect;
+            Name = string.Empty;
+            Description = null;
+            Trigger = ItemEffectTrigger.WhileEquipped;
+            IsCursed = false;
+            RequiresAttunement = false;
+            DurationRounds = null;
+            BehaviorState = null;
+            IconName = null;
+            IsActive = true;
+            Priority = 0;
+        }
+        BusinessRules.CheckRules();
+    }
+
+    [FetchChild]
+    private void Fetch(ItemEffectDefinition dto)
+    {
+        using (BypassPropertyChecks)
+        {
+            Id = dto.Id;
+            ItemTemplateId = dto.ItemTemplateId;
+            EffectDefinitionId = dto.EffectDefinitionId;
+            EffectType = dto.EffectType;
+            Name = dto.Name;
+            Description = dto.Description;
+            Trigger = dto.Trigger;
+            IsCursed = dto.IsCursed;
+            RequiresAttunement = dto.RequiresAttunement;
+            DurationRounds = dto.DurationRounds;
+            BehaviorState = dto.BehaviorState;
+            IconName = dto.IconName;
+            IsActive = dto.IsActive;
+            Priority = dto.Priority;
+        }
+        BusinessRules.CheckRules();
+    }
+
+    /// <summary>
+    /// Converts this business object to a DTO for persistence.
+    /// </summary>
+    internal ItemEffectDefinition ToDto()
+    {
+        return new ItemEffectDefinition
+        {
+            Id = Id,
+            ItemTemplateId = ItemTemplateId,
+            EffectDefinitionId = EffectDefinitionId,
+            EffectType = EffectType,
+            Name = Name,
+            Description = Description,
+            Trigger = Trigger,
+            IsCursed = IsCursed,
+            RequiresAttunement = RequiresAttunement,
+            DurationRounds = DurationRounds,
+            BehaviorState = BehaviorState,
+            IconName = IconName,
+            IsActive = IsActive,
+            Priority = Priority
+        };
+    }
+
+    // Child objects don't need Insert/Update/Delete - they're saved with the parent
+    // The parent ItemTemplateEdit converts the entire Effects list to DTOs when saving
+}
+
+/// <summary>
+/// Validates that a trigger type has been selected (not None).
+/// </summary>
+public class TriggerRequiredRule : BusinessRule
+{
+    public TriggerRequiredRule(IPropertyInfo primaryProperty)
+        : base(primaryProperty)
+    {
+        InputProperties.Add(primaryProperty);
+    }
+
+    protected override void Execute(IRuleContext context)
+    {
+        var value = (ItemEffectTrigger)context.InputPropertyValues[PrimaryProperty]!;
+        if (value == ItemEffectTrigger.None)
+        {
+            context.AddErrorResult("A trigger type must be selected.");
+        }
+    }
+}

--- a/GameMechanics/Items/ItemEffectEditList.cs
+++ b/GameMechanics/Items/ItemEffectEditList.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Csla;
+using Threa.Dal.Dto;
+
+namespace GameMechanics.Items;
+
+/// <summary>
+/// Editable child collection of item effects for an ItemTemplateEdit.
+/// Effects are stored as part of the ItemTemplate and saved/loaded together with it.
+/// </summary>
+[Serializable]
+public class ItemEffectEditList : BusinessListBase<ItemEffectEditList, ItemEffectEdit>
+{
+    [CreateChild]
+    private void Create()
+    {
+        // Empty list for new item templates
+    }
+
+    [FetchChild]
+    private void Fetch(List<ItemEffectDefinition> effects, [Inject] IChildDataPortal<ItemEffectEdit> childPortal)
+    {
+        foreach (var dto in effects)
+        {
+            Add(childPortal.FetchChild(dto));
+        }
+    }
+
+    /// <summary>
+    /// Adds a new effect to the list.
+    /// </summary>
+    /// <param name="itemTemplateId">The parent item template ID.</param>
+    /// <param name="childPortal">The child data portal for creating new effects.</param>
+    /// <returns>The newly created effect.</returns>
+    public ItemEffectEdit AddNewEffect(int itemTemplateId, IChildDataPortal<ItemEffectEdit> childPortal)
+    {
+        var effect = childPortal.CreateChild(itemTemplateId);
+        Add(effect);
+        return effect;
+    }
+
+    /// <summary>
+    /// Converts all effects in this list to DTOs for persistence.
+    /// </summary>
+    internal List<ItemEffectDefinition> ToDtoList()
+    {
+        var list = new List<ItemEffectDefinition>();
+        int localId = 1;
+
+        foreach (var effect in this)
+        {
+            var dto = effect.ToDto();
+            // Assign sequential IDs for effects that don't have one yet
+            if (dto.Id <= 0)
+            {
+                dto.Id = localId++;
+            }
+            else
+            {
+                // Make sure localId stays above existing IDs
+                if (dto.Id >= localId)
+                    localId = dto.Id + 1;
+            }
+            list.Add(dto);
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// Gets effects filtered by trigger type.
+    /// </summary>
+    public IEnumerable<ItemEffectEdit> GetByTrigger(ItemEffectTrigger trigger)
+    {
+        return this.Where(e => e.Trigger == trigger);
+    }
+
+    /// <summary>
+    /// Gets all active effects.
+    /// </summary>
+    public IEnumerable<ItemEffectEdit> GetActiveEffects()
+    {
+        return this.Where(e => e.IsActive);
+    }
+
+    /// <summary>
+    /// Gets all cursed effects.
+    /// </summary>
+    public IEnumerable<ItemEffectEdit> GetCursedEffects()
+    {
+        return this.Where(e => e.IsCursed);
+    }
+}

--- a/Threa/Threa.Client/Components/GameMaster/ItemEffectEditDialog.razor
+++ b/Threa/Threa.Client/Components/GameMaster/ItemEffectEditDialog.razor
@@ -1,0 +1,182 @@
+@using GameMechanics.Items
+@using Threa.Dal.Dto
+@using Radzen
+@using Radzen.Blazor
+
+@inject Radzen.DialogService DialogService
+
+<div class="effect-edit-dialog">
+    <!-- Basic Information Section -->
+    <RadzenFieldset Text="Basic Information" class="mb-3">
+        <div class="row">
+            <div class="col-12 mb-2">
+                <RadzenLabel Text="Effect Name" Component="effectName" />
+                <RadzenTextBox @bind-Value="Effect.Name" Name="effectName" Style="width: 100%"
+                               Placeholder="e.g., Strength Boost, Life Drain" />
+                @if (!string.IsNullOrEmpty(nameError))
+                {
+                    <div class="text-danger small">@nameError</div>
+                }
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12">
+                <RadzenLabel Text="Description" Component="effectDescription" />
+                <RadzenTextArea @bind-Value="Effect.Description" Name="effectDescription"
+                                Rows="2" Style="width: 100%"
+                                Placeholder="What does this effect do?" />
+            </div>
+        </div>
+    </RadzenFieldset>
+
+    <!-- Effect Configuration Section -->
+    <RadzenFieldset Text="Effect Configuration" class="mb-3">
+        <div class="row">
+            <div class="col-6 mb-2">
+                <RadzenLabel Text="Trigger" Component="trigger" />
+                <RadzenDropDown @bind-Value="Effect.Trigger" Data="@_triggers" Name="trigger"
+                                TextProperty="Text" ValueProperty="Value" Style="width: 100%" />
+                <small class="text-muted">@ItemEffectEdit.GetTriggerDescription(Effect.Trigger)</small>
+            </div>
+            <div class="col-6 mb-2">
+                <RadzenLabel Text="Effect Type" Component="effectType" />
+                <RadzenDropDown @bind-Value="Effect.EffectType" Data="@_effectTypes" Name="effectType"
+                                TextProperty="Text" ValueProperty="Value" Style="width: 100%" />
+            </div>
+        </div>
+
+        @if (ShowDurationField)
+        {
+            <div class="row">
+                <div class="col-6">
+                    <RadzenLabel Text="Duration (rounds)" Component="duration" />
+                    <RadzenNumeric @bind-Value="Effect.DurationRounds" Name="duration" Style="width: 100%"
+                                   Min="1" Placeholder="Leave blank for permanent" />
+                    <small class="text-muted">
+                        @if (Effect.Trigger == ItemEffectTrigger.OnUse)
+                        {
+                            <text>How long the effect lasts after use</text>
+                        }
+                        else
+                        {
+                            <text>Leave blank for permanent while trigger condition is met</text>
+                        }
+                    </small>
+                </div>
+                <div class="col-6">
+                    <RadzenLabel Text="Priority" Component="priority" />
+                    <RadzenNumeric @bind-Value="Effect.Priority" Name="priority" Style="width: 100%"
+                                   Placeholder="0" />
+                    <small class="text-muted">Higher priority effects apply first</small>
+                </div>
+            </div>
+        }
+    </RadzenFieldset>
+
+    <!-- Curse Settings Section -->
+    <RadzenFieldset Text="Curse Settings" class="mb-3">
+        <div class="row">
+            <div class="col-6">
+                <RadzenCheckBox @bind-Value="Effect.IsCursed" Name="isCursed" />
+                <RadzenLabel Text="Is Cursed" Component="isCursed" Style="margin-left: 8px" />
+            </div>
+            <div class="col-6">
+                <RadzenCheckBox @bind-Value="Effect.RequiresAttunement" Name="requiresAttunement" />
+                <RadzenLabel Text="Requires Attunement" Component="requiresAttunement" Style="margin-left: 8px" />
+            </div>
+        </div>
+        @if (Effect.IsCursed)
+        {
+            <div class="mt-2">
+                <RadzenAlert AlertStyle="AlertStyle.Warning" ShowIcon="true" Variant="Variant.Flat" Size="AlertSize.Small">
+                    @ItemEffectEdit.GetCurseBlockingDescription(Effect.Trigger)
+                </RadzenAlert>
+            </div>
+        }
+    </RadzenFieldset>
+
+    <!-- Effect Modifiers Section -->
+    <RadzenFieldset Text="Effect Modifiers" class="mb-3">
+        <ItemEffectModifiersEditor @bind-BehaviorState="Effect.BehaviorState" />
+    </RadzenFieldset>
+
+    <!-- Display Section -->
+    <RadzenFieldset Text="Display Settings" class="mb-3">
+        <div class="row">
+            <div class="col-6">
+                <RadzenLabel Text="Icon Name" Component="iconName" />
+                <RadzenTextBox @bind-Value="Effect.IconName" Name="iconName" Style="width: 100%"
+                               Placeholder="e.g., shield, fire, heart" />
+                <small class="text-muted">Icon identifier for UI display</small>
+            </div>
+            <div class="col-6">
+                <RadzenLabel Text="Active" Component="isActive" />
+                <div class="mt-2">
+                    <RadzenCheckBox @bind-Value="Effect.IsActive" Name="isActive" />
+                    <RadzenLabel Text="Effect is active" Component="isActive" Style="margin-left: 8px" />
+                </div>
+            </div>
+        </div>
+    </RadzenFieldset>
+
+    <!-- Dialog Buttons -->
+    <div class="dialog-buttons d-flex justify-content-end gap-2 pt-2 border-top">
+        <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Light" Click="@Cancel" />
+        <RadzenButton Text="Save" ButtonStyle="ButtonStyle.Primary" Click="@Save" />
+    </div>
+</div>
+
+@code {
+    [Parameter]
+    public required ItemEffectEdit Effect { get; set; }
+
+    private string? nameError;
+
+    private readonly List<DropdownItem<ItemEffectTrigger>> _triggers =
+    [
+        new("While Equipped", ItemEffectTrigger.WhileEquipped),
+        new("While Possessed", ItemEffectTrigger.WhilePossessed),
+        new("On Pickup", ItemEffectTrigger.OnPickup),
+        new("On Use", ItemEffectTrigger.OnUse),
+        new("On Attack With", ItemEffectTrigger.OnAttackWith),
+        new("On Hit While Wearing", ItemEffectTrigger.OnHitWhileWearing),
+        new("On Critical", ItemEffectTrigger.OnCritical)
+    ];
+
+    private readonly List<DropdownItem<EffectType>> _effectTypes =
+    [
+        new("Item Effect", EffectType.ItemEffect),
+        new("Buff", EffectType.Buff),
+        new("Debuff", EffectType.Debuff),
+        new("Condition", EffectType.Condition),
+        new("Poison", EffectType.Poison),
+        new("Disease", EffectType.Disease),
+        new("Spell Effect", EffectType.SpellEffect)
+    ];
+
+    private bool ShowDurationField => Effect.Trigger == ItemEffectTrigger.OnUse ||
+                                       Effect.Trigger == ItemEffectTrigger.OnAttackWith ||
+                                       Effect.Trigger == ItemEffectTrigger.OnHitWhileWearing ||
+                                       Effect.Trigger == ItemEffectTrigger.OnCritical;
+
+    private void Save()
+    {
+        // Validate
+        nameError = null;
+        if (string.IsNullOrWhiteSpace(Effect.Name))
+        {
+            nameError = "Effect name is required.";
+            return;
+        }
+
+        DialogService.Close(true);
+    }
+
+    private void Cancel()
+    {
+        DialogService.Close(false);
+    }
+
+    // Helper class for dropdown items
+    private record DropdownItem<T>(string Text, T Value);
+}

--- a/Threa/Threa.Client/Components/GameMaster/ItemEffectModifiersEditor.razor
+++ b/Threa/Threa.Client/Components/GameMaster/ItemEffectModifiersEditor.razor
@@ -1,0 +1,199 @@
+@using GameMechanics.Effects.Behaviors
+@using System.Text.Json
+@using Radzen
+@using Radzen.Blazor
+
+<div class="modifiers-editor">
+    <div class="mb-2">
+        <RadzenButton Text="Add Modifier" Icon="add" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Secondary"
+                      Click="@AddModifier" />
+    </div>
+
+    @if (_state.Modifiers.Count == 0)
+    {
+        <div class="text-muted small p-2 border rounded">
+            No modifiers defined. Add modifiers to specify what this effect does.
+        </div>
+    }
+    else
+    {
+        <div class="modifiers-list">
+            @foreach (var (modifier, index) in _state.Modifiers.Select((m, i) => (m, i)))
+            {
+                <div class="modifier-row d-flex align-items-center gap-2 p-2 border-bottom" @key="index">
+                    <RadzenDropDown @bind-Value="modifier.Type" Data="@_modifierTypes"
+                                    TextProperty="Text" ValueProperty="Value"
+                                    Style="width: 150px" Change="@((object args) => OnChange())" />
+
+                    @switch (modifier.Type)
+                    {
+                        case BuffModifierType.Attribute:
+                            <RadzenDropDown @bind-Value="modifier.Target" Data="@_attributes"
+                                            Style="width: 100px" Change="@((object args) => OnChange())"
+                                            Placeholder="Attr" />
+                            <RadzenNumeric @bind-Value="modifier.Value" Style="width: 80px"
+                                           Change="@((int args) => OnChange())" />
+                            <span class="text-muted small">bonus</span>
+                            break;
+
+                        case BuffModifierType.AbilityScoreGlobal:
+                            <span class="text-muted">All skills</span>
+                            <RadzenNumeric @bind-Value="modifier.Value" Style="width: 80px"
+                                           Change="@((int args) => OnChange())" />
+                            <span class="text-muted small">bonus</span>
+                            break;
+
+                        case BuffModifierType.AbilityScoreSkill:
+                            <RadzenTextBox @bind-Value="modifier.Target" Style="width: 150px"
+                                           Placeholder="Skill name" Change="@((string args) => OnChange())" />
+                            <RadzenNumeric @bind-Value="modifier.Value" Style="width: 80px"
+                                           Change="@((int args) => OnChange())" />
+                            <span class="text-muted small">bonus</span>
+                            break;
+
+                        case BuffModifierType.SuccessValueGlobal:
+                            <span class="text-muted">All SVs</span>
+                            <RadzenNumeric @bind-Value="modifier.Value" Style="width: 80px"
+                                           Change="@((int args) => OnChange())" />
+                            <span class="text-muted small">bonus</span>
+                            break;
+
+                        case BuffModifierType.SuccessValueAction:
+                            <RadzenTextBox @bind-Value="modifier.Target" Style="width: 150px"
+                                           Placeholder="Action type" Change="@((string args) => OnChange())" />
+                            <RadzenNumeric @bind-Value="modifier.Value" Style="width: 80px"
+                                           Change="@((int args) => OnChange())" />
+                            <span class="text-muted small">bonus</span>
+                            break;
+
+                        case BuffModifierType.HealingOverTime:
+                            <RadzenDropDown @bind-Value="modifier.Target" Data="@_healthPools"
+                                            Style="width: 80px" Change="@((object args) => OnChange())"
+                                            Placeholder="Pool" />
+                            <RadzenNumeric @bind-Value="modifier.Value" Style="width: 80px"
+                                           Change="@((int args) => OnChange())" />
+                            <span class="text-muted small">per</span>
+                            <RadzenNumeric @bind-Value="modifier.HealIntervalRounds" Style="width: 80px"
+                                           Min="1" Change="@((int args) => OnChange())" />
+                            <span class="text-muted small">rounds</span>
+                            <span class="text-info small ms-2">
+                                @if (modifier.Value > 0)
+                                {
+                                    <text>(heals)</text>
+                                }
+                                else
+                                {
+                                    <text>(damages)</text>
+                                }
+                            </span>
+                            break;
+                    }
+
+                    <RadzenButton Icon="delete" Size="ButtonSize.ExtraSmall" ButtonStyle="ButtonStyle.Danger"
+                                  Click="@(() => RemoveModifier(modifier))" title="Remove modifier" />
+                </div>
+            }
+        </div>
+    }
+
+    <!-- Advanced Settings -->
+    <RadzenPanel AllowCollapse="true" Collapsed="true" class="mt-3">
+        <HeaderTemplate>
+            <span class="small">Advanced Settings</span>
+        </HeaderTemplate>
+        <ChildContent>
+            <div class="p-2">
+                <div class="row mb-2">
+                    <div class="col-6">
+                        <RadzenLabel Text="Effect Name Override" Component="effectName" />
+                        <RadzenTextBox @bind-Value="_state.EffectName" Name="effectName" Style="width: 100%"
+                                       Placeholder="Display name in effect list" Change="@((string args) => OnChange())" />
+                    </div>
+                    <div class="col-6">
+                        <RadzenLabel Text="Item Name" Component="itemName" />
+                        <RadzenTextBox @bind-Value="_state.ItemName" Name="itemName" Style="width: 100%"
+                                       Placeholder="Source item display name" Change="@((string args) => OnChange())" />
+                    </div>
+                </div>
+                <div class="row mb-2">
+                    <div class="col-4">
+                        <RadzenLabel Text="Identify Difficulty" Component="identifyDiff" />
+                        <RadzenNumeric @bind-Value="_state.IdentifyDifficulty" Name="identifyDiff"
+                                       Style="width: 100%" Min="0" Change="@((int args) => OnChange())" />
+                    </div>
+                    <div class="col-4">
+                        <RadzenLabel Text="Removal Difficulty" Component="removalDiff" />
+                        <RadzenNumeric @bind-Value="_state.RemovalDifficulty" Name="removalDiff"
+                                       Style="width: 100%" Min="0" Change="@((int args) => OnChange())" />
+                    </div>
+                    <div class="col-4 d-flex align-items-end">
+                        <div>
+                            <RadzenCheckBox @bind-Value="_state.IsRevealed" Name="isRevealed" />
+                            <RadzenLabel Text="Initially Revealed" Component="isRevealed" Style="margin-left: 8px" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </ChildContent>
+    </RadzenPanel>
+</div>
+
+@code {
+    [Parameter]
+    public string? BehaviorState { get; set; }
+
+    [Parameter]
+    public EventCallback<string?> BehaviorStateChanged { get; set; }
+
+    private ItemEffectState _state = new();
+
+    private readonly List<DropdownItem<BuffModifierType>> _modifierTypes =
+    [
+        new("Attribute", BuffModifierType.Attribute),
+        new("Skill Bonus", BuffModifierType.AbilityScoreSkill),
+        new("All Skills", BuffModifierType.AbilityScoreGlobal),
+        new("SV (Global)", BuffModifierType.SuccessValueGlobal),
+        new("SV (Action)", BuffModifierType.SuccessValueAction),
+        new("Heal/Damage", BuffModifierType.HealingOverTime)
+    ];
+
+    private readonly List<string> _attributes = ["STR", "DEX", "END", "INT", "ITT", "WIL", "PHY"];
+    private readonly List<string> _healthPools = ["FAT", "VIT"];
+
+    protected override void OnParametersSet()
+    {
+        _state = ItemEffectState.Deserialize(BehaviorState);
+    }
+
+    private void AddModifier()
+    {
+        _state.Modifiers.Add(new BuffModifier
+        {
+            Type = BuffModifierType.Attribute,
+            Target = "STR",
+            Value = 1
+        });
+        UpdateBehaviorState();
+    }
+
+    private void RemoveModifier(BuffModifier modifier)
+    {
+        _state.Modifiers.Remove(modifier);
+        UpdateBehaviorState();
+    }
+
+    private void OnChange()
+    {
+        UpdateBehaviorState();
+    }
+
+    private void UpdateBehaviorState()
+    {
+        var json = _state.Modifiers.Count > 0 || !string.IsNullOrEmpty(_state.EffectName)
+            ? _state.Serialize()
+            : null;
+        BehaviorStateChanged.InvokeAsync(json);
+    }
+
+    private record DropdownItem<T>(string Text, T Value);
+}

--- a/Threa/Threa.Client/Components/GameMaster/ItemEffectsEditor.razor
+++ b/Threa/Threa.Client/Components/GameMaster/ItemEffectsEditor.razor
@@ -1,0 +1,128 @@
+@using GameMechanics.Items
+@using Threa.Dal.Dto
+@using Csla
+@using Radzen
+@using Radzen.Blazor
+
+@inject IChildDataPortal<ItemEffectEdit> effectPortal
+@inject Radzen.DialogService DialogService
+
+<div class="effects-editor">
+    <div class="effects-toolbar mb-3">
+        <RadzenButton Text="Add Effect" Icon="add" ButtonStyle="ButtonStyle.Success" Size="ButtonSize.Small"
+                      Click="@AddEffect" />
+    </div>
+
+    @if (Item.Effects.Count == 0)
+    {
+        <div class="no-effects-message alert alert-info">
+            <p class="mb-1"><strong>No effects defined for this item.</strong></p>
+            <p class="mb-0 text-muted small">
+                Effects allow items to apply buffs, debuffs, or special abilities when equipped, possessed, or used.
+                Click "Add Effect" to define a new effect.
+            </p>
+        </div>
+    }
+    else
+    {
+        <RadzenDataGrid Data="@Item.Effects" TItem="ItemEffectEdit" AllowSorting="true" AllowFiltering="false"
+                        GridLines="DataGridGridLines.Both" Density="Density.Compact">
+            <Columns>
+                <RadzenDataGridColumn TItem="ItemEffectEdit" Property="Name" Title="Effect Name" Width="180px" />
+                <RadzenDataGridColumn TItem="ItemEffectEdit" Property="TriggerDisplayName" Title="Trigger" Width="130px" />
+                <RadzenDataGridColumn TItem="ItemEffectEdit" Property="EffectType" Title="Type" Width="100px">
+                    <Template Context="effect">
+                        <span class="badge @GetEffectTypeBadgeClass(effect.EffectType)">@effect.EffectType</span>
+                    </Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn TItem="ItemEffectEdit" Title="Flags" Width="120px">
+                    <Template Context="effect">
+                        @if (effect.IsCursed)
+                        {
+                            <span class="badge bg-danger me-1" title="Cursed">Cursed</span>
+                        }
+                        @if (effect.RequiresAttunement)
+                        {
+                            <span class="badge bg-info me-1" title="Requires Attunement">Attune</span>
+                        }
+                        @if (effect.DurationRounds.HasValue)
+                        {
+                            <span class="badge bg-secondary" title="@(effect.DurationRounds) rounds">@effect.DurationRounds rnd</span>
+                        }
+                    </Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn TItem="ItemEffectEdit" Property="Description" Title="Description" />
+                <RadzenDataGridColumn TItem="ItemEffectEdit" Title="Actions" Width="100px" Sortable="false" TextAlign="TextAlign.Center">
+                    <Template Context="effect">
+                        <RadzenButton Icon="edit" Size="ButtonSize.ExtraSmall" ButtonStyle="ButtonStyle.Light"
+                                      Click="@(() => EditEffect(effect))" title="Edit effect" class="me-1" />
+                        <RadzenButton Icon="delete" Size="ButtonSize.ExtraSmall" ButtonStyle="ButtonStyle.Danger"
+                                      Click="@(() => DeleteEffect(effect))" title="Delete effect" />
+                    </Template>
+                </RadzenDataGridColumn>
+            </Columns>
+        </RadzenDataGrid>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public required ItemTemplateEdit Item { get; set; }
+
+    private async Task AddEffect()
+    {
+        var newEffect = Item.Effects.AddNewEffect(Item.Id, effectPortal);
+        await EditEffect(newEffect);
+    }
+
+    private async Task EditEffect(ItemEffectEdit effect)
+    {
+        var result = await DialogService.OpenAsync<ItemEffectEditDialog>(
+            effect.IsNew ? "Add Effect" : "Edit Effect",
+            new Dictionary<string, object> { { "Effect", effect } },
+            new DialogOptions
+            {
+                Width = "700px",
+                Height = "auto",
+                Resizable = true,
+                Draggable = true,
+                CloseDialogOnOverlayClick = false
+            });
+
+        // If dialog returned false (cancelled) and this is a new effect, remove it
+        if (result is false && effect.IsNew)
+        {
+            Item.Effects.Remove(effect);
+        }
+    }
+
+    private async Task DeleteEffect(ItemEffectEdit effect)
+    {
+        var confirmed = await DialogService.Confirm(
+            $"Delete effect '{effect.Name}'?",
+            "Confirm Delete",
+            new ConfirmOptions
+            {
+                OkButtonText = "Delete",
+                CancelButtonText = "Cancel"
+            });
+
+        if (confirmed == true)
+        {
+            Item.Effects.Remove(effect);
+        }
+    }
+
+    private string GetEffectTypeBadgeClass(EffectType type) => type switch
+    {
+        EffectType.Buff => "bg-success",
+        EffectType.Debuff => "bg-warning text-dark",
+        EffectType.ItemEffect => "bg-primary",
+        EffectType.Wound => "bg-danger",
+        EffectType.Poison => "bg-danger",
+        EffectType.Disease => "bg-warning text-dark",
+        EffectType.Condition => "bg-secondary",
+        EffectType.SpellEffect => "bg-info",
+        _ => "bg-secondary"
+    };
+}

--- a/Threa/Threa.Client/Components/Pages/GameMaster/ItemEdit.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/ItemEdit.razor
@@ -699,6 +699,19 @@ else
                         </table>
                     </RadzenTabsItem>
                 }
+
+                    <!-- ========================== -->
+                    <!-- EFFECTS TAB (Always visible) -->
+                    <!-- ========================== -->
+                    <RadzenTabsItem Text="Effects">
+                        <div class="info-box mt-3">
+                            <strong>Item Effects</strong>
+                            <span class="badge bg-secondary ms-2">@(vm.Model.Effects?.Count ?? 0)</span>
+                        </div>
+                        <div class="mt-3">
+                            <Threa.Client.Components.GameMaster.ItemEffectsEditor Item="@vm.Model" />
+                        </div>
+                    </RadzenTabsItem>
                 </Tabs>
             </RadzenTabs>
         </div>


### PR DESCRIPTION
## Summary

- Implements the ITEM_EFFECTS_EDITOR_PLAN.md design for adding item effect management to the GM editor
- Adds CSLA child business objects (ItemEffectEdit, ItemEffectEditList) with validation rules
- Creates Blazor UI components (ItemEffectsEditor, ItemEffectEditDialog, ItemEffectModifiersEditor)
- Adds Effects tab to ItemEdit.razor page for managing item effects
- Effects persisted within ItemTemplate JSON - no separate DAL needed

## Features

Effects can be configured with:
- **Triggers**: WhileEquipped, WhilePossessed, OnUse, OnAttackWith, OnHitWhileWearing, OnCritical, OnPickup
- **Types**: Buff, Debuff, ItemEffect, Condition, Poison, Disease, SpellEffect
- **Modifiers**: Attribute bonuses, skill bonuses (global/specific), SV bonuses, healing/damage over time
- **Options**: Curse settings, attunement requirements, duration, priority

## Test plan

- [ ] Create a new item and verify Effects tab is present
- [ ] Add a new effect with WhileEquipped trigger and Attribute modifier
- [ ] Save the item and re-open it - verify effect persists
- [ ] Edit existing effect and verify changes persist
- [ ] Delete an effect and verify it's removed
- [ ] Create a cursed item effect and verify curse warning appears
- [ ] Verify validation prevents saving effects without name or valid trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)