### PR TITLE
feat: implement end-to-end implant system

### DIFF
--- a/GameMechanics.Test/ImplantTests.cs
+++ b/GameMechanics.Test/ImplantTests.cs
@@ -1,0 +1,415 @@
+using Csla;
+using GameMechanics.Combat;
+using GameMechanics.Effects;
+using GameMechanics.Items;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Threa.Dal.Dto;
+
+namespace GameMechanics.Test;
+
+[TestClass]
+public class ImplantTests : TestBase
+{
+  protected override void ConfigureAdditionalServices(IServiceCollection services)
+  {
+    services.AddGameMechanics();
+  }
+
+  #region Always-On Implant Effects
+
+  [TestMethod]
+  public async Task EquippingAlwaysOnImplant_AppliesWhileEquippedEffect()
+  {
+    var provider = InitServices();
+    var dp = provider.GetRequiredService<IDataPortal<CharacterEdit>>();
+    var service = provider.GetRequiredService<ItemEffectService>();
+    var c = dp.Create(42);
+
+    var item = new CharacterItem { Id = Guid.NewGuid() };
+    var template = new ItemTemplate
+    {
+      Id = 200,
+      Name = "Subdermal Armor",
+      ItemType = ItemType.Implant,
+      EquipmentSlot = EquipmentSlot.ImplantSubdermal,
+      Effects =
+      [
+        new ItemEffectDefinition
+        {
+          EffectType = EffectType.Buff,
+          Name = "Subdermal Armor",
+          Trigger = ItemEffectTrigger.WhileEquipped,
+          IsActive = true,
+          IsToggleable = false
+        }
+      ]
+    };
+
+    var result = await service.OnItemEquippedAsync(c, item, template);
+
+    Assert.IsTrue(result.Success);
+    Assert.AreEqual(1, result.AppliedEffects.Count);
+    Assert.AreEqual("Subdermal Armor", result.AppliedEffects[0].Name);
+  }
+
+  [TestMethod]
+  public async Task UnequippingAlwaysOnImplant_RemovesEffect()
+  {
+    var provider = InitServices();
+    var dp = provider.GetRequiredService<IDataPortal<CharacterEdit>>();
+    var service = provider.GetRequiredService<ItemEffectService>();
+    var c = dp.Create(42);
+
+    var item = new CharacterItem { Id = Guid.NewGuid() };
+    var template = new ItemTemplate
+    {
+      Id = 200,
+      Name = "Subdermal Armor",
+      ItemType = ItemType.Implant,
+      Effects =
+      [
+        new ItemEffectDefinition
+        {
+          EffectType = EffectType.Buff,
+          Name = "Subdermal Armor",
+          Trigger = ItemEffectTrigger.WhileEquipped,
+          IsActive = true,
+          IsToggleable = false
+        }
+      ]
+    };
+
+    await service.OnItemEquippedAsync(c, item, template);
+    Assert.AreEqual(1, c.Effects.Count);
+
+    var unequipResult = service.OnItemUnequipped(c, item.Id);
+    Assert.IsTrue(unequipResult.Success);
+    Assert.AreEqual(0, c.Effects.Count);
+  }
+
+  #endregion
+
+  #region Toggleable Implant Effects
+
+  [TestMethod]
+  public async Task EquippingToggleableImplant_DoesNotAutoApplyEffect()
+  {
+    var provider = InitServices();
+    var dp = provider.GetRequiredService<IDataPortal<CharacterEdit>>();
+    var service = provider.GetRequiredService<ItemEffectService>();
+    var c = dp.Create(42);
+
+    var item = new CharacterItem { Id = Guid.NewGuid() };
+    var template = new ItemTemplate
+    {
+      Id = 201,
+      Name = "Wired Reflexes",
+      ItemType = ItemType.Implant,
+      Effects =
+      [
+        new ItemEffectDefinition
+        {
+          EffectType = EffectType.Buff,
+          Name = "Wired Reflexes",
+          Trigger = ItemEffectTrigger.WhileEquipped,
+          IsActive = true,
+          IsToggleable = true,
+          ToggleApCost = 1
+        }
+      ]
+    };
+
+    var result = await service.OnItemEquippedAsync(c, item, template);
+
+    Assert.IsTrue(result.Success);
+    Assert.AreEqual(0, result.AppliedEffects.Count, "Toggleable effects should not auto-apply on equip");
+    Assert.AreEqual(0, c.Effects.Count);
+  }
+
+  [TestMethod]
+  public async Task ToggleOn_AppliesEffect_ToggleOff_RemovesEffect()
+  {
+    var provider = InitServices();
+    var dp = provider.GetRequiredService<IDataPortal<CharacterEdit>>();
+    var service = provider.GetRequiredService<ItemEffectService>();
+    var c = dp.Create(42);
+
+    var itemId = Guid.NewGuid();
+    var effectDef = new ItemEffectDefinition
+    {
+      EffectType = EffectType.Buff,
+      Name = "Wired Reflexes",
+      Trigger = ItemEffectTrigger.WhileEquipped,
+      IsActive = true,
+      IsToggleable = true,
+      ToggleApCost = 0
+    };
+
+    // Toggle ON
+    var onResult = await service.ToggleImplantEffectOnAsync(c, itemId, effectDef);
+    Assert.IsTrue(onResult.Success);
+    Assert.AreEqual(1, onResult.AppliedEffects.Count);
+    Assert.AreEqual(1, c.Effects.Count);
+    Assert.AreEqual("Wired Reflexes", c.Effects[0].Name);
+
+    // Toggle OFF
+    var offResult = service.ToggleImplantEffectOff(c, itemId, effectDef);
+    Assert.IsTrue(offResult.Success);
+    Assert.AreEqual(1, offResult.RemovedEffectIds.Count);
+    Assert.AreEqual(0, c.Effects.Count);
+  }
+
+  [TestMethod]
+  public async Task ToggleOn_WithApCost_DeductsAP()
+  {
+    var provider = InitServices();
+    var dp = provider.GetRequiredService<IDataPortal<CharacterEdit>>();
+    var service = provider.GetRequiredService<ItemEffectService>();
+    var c = dp.Create(42);
+
+    int initialAP = c.ActionPoints.Available;
+    var itemId = Guid.NewGuid();
+    var effectDef = new ItemEffectDefinition
+    {
+      EffectType = EffectType.Buff,
+      Name = "Wired Reflexes",
+      Trigger = ItemEffectTrigger.WhileEquipped,
+      IsActive = true,
+      IsToggleable = true,
+      ToggleApCost = 1
+    };
+
+    var result = await service.ToggleImplantEffectOnAsync(c, itemId, effectDef);
+
+    Assert.IsTrue(result.Success);
+    Assert.AreEqual(initialAP - 1, c.ActionPoints.Available);
+  }
+
+  [TestMethod]
+  public async Task ToggleOn_InsufficientAP_Fails()
+  {
+    var provider = InitServices();
+    var dp = provider.GetRequiredService<IDataPortal<CharacterEdit>>();
+    var service = provider.GetRequiredService<ItemEffectService>();
+    var c = dp.Create(42);
+
+    // Drain all AP
+    c.ActionPoints.Available = 0;
+
+    var itemId = Guid.NewGuid();
+    var effectDef = new ItemEffectDefinition
+    {
+      EffectType = EffectType.Buff,
+      Name = "Wired Reflexes",
+      Trigger = ItemEffectTrigger.WhileEquipped,
+      IsActive = true,
+      IsToggleable = true,
+      ToggleApCost = 1
+    };
+
+    var result = await service.ToggleImplantEffectOnAsync(c, itemId, effectDef);
+
+    Assert.IsFalse(result.Success);
+    Assert.IsTrue(result.ErrorMessage!.Contains("Insufficient AP"));
+    Assert.AreEqual(0, c.Effects.Count);
+  }
+
+  [TestMethod]
+  public async Task ToggleOn_AlreadyActive_Fails()
+  {
+    var provider = InitServices();
+    var dp = provider.GetRequiredService<IDataPortal<CharacterEdit>>();
+    var service = provider.GetRequiredService<ItemEffectService>();
+    var c = dp.Create(42);
+
+    var itemId = Guid.NewGuid();
+    var effectDef = new ItemEffectDefinition
+    {
+      EffectType = EffectType.Buff,
+      Name = "Wired Reflexes",
+      Trigger = ItemEffectTrigger.WhileEquipped,
+      IsActive = true,
+      IsToggleable = true,
+      ToggleApCost = 0
+    };
+
+    await service.ToggleImplantEffectOnAsync(c, itemId, effectDef);
+
+    var secondResult = await service.ToggleImplantEffectOnAsync(c, itemId, effectDef);
+    Assert.IsFalse(secondResult.Success);
+    Assert.IsTrue(secondResult.ErrorMessage!.Contains("already active"));
+  }
+
+  [TestMethod]
+  public void ToggleOff_NotActive_Fails()
+  {
+    var provider = InitServices();
+    var dp = provider.GetRequiredService<IDataPortal<CharacterEdit>>();
+    var service = provider.GetRequiredService<ItemEffectService>();
+    var c = dp.Create(42);
+
+    var itemId = Guid.NewGuid();
+    var effectDef = new ItemEffectDefinition
+    {
+      EffectType = EffectType.Buff,
+      Name = "Wired Reflexes",
+      Trigger = ItemEffectTrigger.WhileEquipped,
+      IsActive = true,
+      IsToggleable = true,
+      ToggleApCost = 0
+    };
+
+    var result = service.ToggleImplantEffectOff(c, itemId, effectDef);
+    Assert.IsFalse(result.Success);
+    Assert.IsTrue(result.ErrorMessage!.Contains("not currently active"));
+  }
+
+  [TestMethod]
+  public void ToggleOff_NonToggleable_Fails()
+  {
+    var provider = InitServices();
+    var dp = provider.GetRequiredService<IDataPortal<CharacterEdit>>();
+    var service = provider.GetRequiredService<ItemEffectService>();
+    var c = dp.Create(42);
+
+    var itemId = Guid.NewGuid();
+    var effectDef = new ItemEffectDefinition
+    {
+      EffectType = EffectType.Buff,
+      Name = "Subdermal Armor",
+      Trigger = ItemEffectTrigger.WhileEquipped,
+      IsActive = true,
+      IsToggleable = false
+    };
+
+    var result = service.ToggleImplantEffectOff(c, itemId, effectDef);
+    Assert.IsFalse(result.Success);
+    Assert.IsTrue(result.ErrorMessage!.Contains("not toggleable"));
+  }
+
+  #endregion
+
+  #region Implant Weapons via WeaponSelector
+
+  [TestMethod]
+  public void WeaponSelector_GetMeleeWeapons_FindsImplantMeleeWeapon()
+  {
+    var items = new List<EquippedItemInfo>
+    {
+      new(
+        new CharacterItem { Id = Guid.NewGuid(), EquippedSlot = EquipmentSlot.ImplantHandRight },
+        new ItemTemplate
+        {
+          Id = 202,
+          Name = "Retractable Blade",
+          ItemType = ItemType.Implant,
+          WeaponType = WeaponType.Dagger,
+          DamageClass = 2,
+          DamageType = "Cutting"
+        })
+    };
+
+    var meleeWeapons = WeaponSelector.GetMeleeWeapons(items).ToList();
+
+    Assert.AreEqual(1, meleeWeapons.Count);
+    Assert.AreEqual("Retractable Blade", meleeWeapons[0].Template.Name);
+  }
+
+  [TestMethod]
+  public void WeaponSelector_GetRangedWeapons_FindsImplantRangedWeapon()
+  {
+    var items = new List<EquippedItemInfo>
+    {
+      new(
+        new CharacterItem { Id = Guid.NewGuid(), EquippedSlot = EquipmentSlot.ImplantArmRight },
+        new ItemTemplate
+        {
+          Id = 210,
+          Name = "Built-in Laser",
+          ItemType = ItemType.Implant,
+          WeaponType = WeaponType.Pistol,
+          Range = 30,
+          DamageClass = 2,
+          DamageType = "Energy"
+        })
+    };
+
+    var rangedWeapons = WeaponSelector.GetRangedWeapons(items).ToList();
+
+    Assert.AreEqual(1, rangedWeapons.Count);
+    Assert.AreEqual("Built-in Laser", rangedWeapons[0].Template.Name);
+  }
+
+  [TestMethod]
+  public void WeaponSelector_GetMeleeWeapons_ExcludesImplantRangedWeapon()
+  {
+    var items = new List<EquippedItemInfo>
+    {
+      new(
+        new CharacterItem { Id = Guid.NewGuid(), EquippedSlot = EquipmentSlot.ImplantArmRight },
+        new ItemTemplate
+        {
+          Id = 210,
+          Name = "Built-in Laser",
+          ItemType = ItemType.Implant,
+          WeaponType = WeaponType.Pistol,
+          Range = 30
+        })
+    };
+
+    var meleeWeapons = WeaponSelector.GetMeleeWeapons(items).ToList();
+
+    Assert.AreEqual(0, meleeWeapons.Count, "Ranged implant weapon should not appear in melee list");
+  }
+
+  [TestMethod]
+  public void WeaponSelector_GetMeleeWeapons_IgnoresImplantWithNoWeaponType()
+  {
+    var items = new List<EquippedItemInfo>
+    {
+      new(
+        new CharacterItem { Id = Guid.NewGuid(), EquippedSlot = EquipmentSlot.ImplantSpine },
+        new ItemTemplate
+        {
+          Id = 201,
+          Name = "Wired Reflexes",
+          ItemType = ItemType.Implant,
+          WeaponType = WeaponType.None
+        })
+    };
+
+    var meleeWeapons = WeaponSelector.GetMeleeWeapons(items).ToList();
+    var rangedWeapons = WeaponSelector.GetRangedWeapons(items).ToList();
+
+    Assert.AreEqual(0, meleeWeapons.Count, "Non-weapon implant should not appear in melee list");
+    Assert.AreEqual(0, rangedWeapons.Count, "Non-weapon implant should not appear in ranged list");
+  }
+
+  [TestMethod]
+  public void ImplantWeapon_Modifiers_ApplyCorrectly()
+  {
+    var template = new ItemTemplate
+    {
+      Id = 202,
+      Name = "Retractable Blade",
+      ItemType = ItemType.Implant,
+      WeaponType = WeaponType.Dagger,
+      DamageClass = 2,
+      DamageType = "Cutting",
+      SVModifier = 1,
+      AVModifier = -1
+    };
+
+    Assert.AreEqual(2, template.DamageClass);
+    Assert.AreEqual("Cutting", template.DamageType);
+    Assert.AreEqual(1, template.SVModifier);
+    Assert.AreEqual(-1, template.AVModifier);
+  }
+
+  #endregion
+}

--- a/GameMechanics/Combat/EquipmentLocationMapper.cs
+++ b/GameMechanics/Combat/EquipmentLocationMapper.cs
@@ -48,6 +48,8 @@ namespace GameMechanics.Combat
         EquipmentSlot.ImplantArmRight => [HitLocation.RightArm],
         EquipmentSlot.ImplantLegLeft => [HitLocation.LeftLeg],
         EquipmentSlot.ImplantLegRight => [HitLocation.RightLeg],
+        EquipmentSlot.ImplantFootLeft => [HitLocation.LeftLeg],
+        EquipmentSlot.ImplantFootRight => [HitLocation.RightLeg],
 
         // Weapons, jewelry, and other slots don't provide armor coverage
         _ => []
@@ -71,9 +73,11 @@ namespace GameMechanics.Combat
         HitLocation.RightArm => [EquipmentSlot.ArmRight, EquipmentSlot.WristRight,
                                  EquipmentSlot.HandRight, EquipmentSlot.ImplantArmRight],
         HitLocation.LeftLeg => [EquipmentSlot.Legs, EquipmentSlot.AnkleLeft,
-                                EquipmentSlot.FootLeft, EquipmentSlot.ImplantLegLeft],
+                                EquipmentSlot.FootLeft, EquipmentSlot.ImplantLegLeft,
+                                EquipmentSlot.ImplantFootLeft],
         HitLocation.RightLeg => [EquipmentSlot.Legs, EquipmentSlot.AnkleRight,
-                                 EquipmentSlot.FootRight, EquipmentSlot.ImplantLegRight],
+                                 EquipmentSlot.FootRight, EquipmentSlot.ImplantLegRight,
+                                 EquipmentSlot.ImplantFootRight],
         _ => []
       };
     }

--- a/GameMechanics/Combat/WeaponSelector.cs
+++ b/GameMechanics/Combat/WeaponSelector.cs
@@ -14,27 +14,29 @@ public static class WeaponSelector
     /// <summary>
     /// Gets melee weapons from equipped items.
     /// Melee = weapon in MainHand/OffHand/TwoHand with no Range property AND not flagged as ranged in CustomProperties.
+    /// Also includes implant weapons that are melee.
     /// </summary>
     public static IEnumerable<EquippedItemInfo> GetMeleeWeapons(
         IEnumerable<EquippedItemInfo> equippedItems)
     {
         return equippedItems.Where(i =>
-            i.Template.ItemType == ItemType.Weapon &&
-            IsWeaponSlot(i.Item.EquippedSlot) &&
-            !IsRangedWeapon(i));
+            (i.Template.ItemType == ItemType.Weapon && IsWeaponSlot(i.Item.EquippedSlot) && !IsRangedWeapon(i)) ||
+            (i.Template.ItemType == ItemType.Implant && IsImplantWeaponSlot(i.Item.EquippedSlot) &&
+             i.Template.WeaponType != WeaponType.None && !IsRangedWeapon(i)));
     }
 
     /// <summary>
     /// Gets ranged weapons from equipped items.
     /// Ranged = weapon in MainHand/OffHand/TwoHand with Range property OR RangedWeaponProperties.IsRangedWeapon == true.
+    /// Also includes implant weapons that are ranged.
     /// </summary>
     public static IEnumerable<EquippedItemInfo> GetRangedWeapons(
         IEnumerable<EquippedItemInfo> equippedItems)
     {
         return equippedItems.Where(i =>
-            i.Template.ItemType == ItemType.Weapon &&
-            IsWeaponSlot(i.Item.EquippedSlot) &&
-            IsRangedWeapon(i));
+            (i.Template.ItemType == ItemType.Weapon && IsWeaponSlot(i.Item.EquippedSlot) && IsRangedWeapon(i)) ||
+            (i.Template.ItemType == ItemType.Implant && IsImplantWeaponSlot(i.Item.EquippedSlot) &&
+             i.Template.WeaponType != WeaponType.None && IsRangedWeapon(i)));
     }
 
     /// <summary>
@@ -55,4 +57,7 @@ public static class WeaponSelector
         slot == EquipmentSlot.MainHand ||
         slot == EquipmentSlot.OffHand ||
         slot == EquipmentSlot.TwoHand;
+
+    private static bool IsImplantWeaponSlot(EquipmentSlot slot) =>
+        slot.IsImplant();
 }

--- a/GameMechanics/Items/ItemEffectEdit.cs
+++ b/GameMechanics/Items/ItemEffectEdit.cs
@@ -112,6 +112,20 @@ public class ItemEffectEdit : BusinessBase<ItemEffectEdit>
         set => SetProperty(PriorityProperty, value);
     }
 
+    public static readonly PropertyInfo<bool> IsToggleableProperty = RegisterProperty<bool>(nameof(IsToggleable));
+    public bool IsToggleable
+    {
+        get => GetProperty(IsToggleableProperty);
+        set => SetProperty(IsToggleableProperty, value);
+    }
+
+    public static readonly PropertyInfo<int> ToggleApCostProperty = RegisterProperty<int>(nameof(ToggleApCost));
+    public int ToggleApCost
+    {
+        get => GetProperty(ToggleApCostProperty);
+        set => SetProperty(ToggleApCostProperty, value);
+    }
+
     /// <summary>
     /// Gets the display name for the trigger type.
     /// </summary>
@@ -133,6 +147,9 @@ public class ItemEffectEdit : BusinessBase<ItemEffectEdit>
     private string BuildEffectSummary()
     {
         var parts = new System.Collections.Generic.List<string>();
+
+        if (IsToggleable)
+            parts.Add(ToggleApCost > 0 ? $"Toggleable ({ToggleApCost} AP)" : "Toggleable (Free)");
 
         if (IsCursed)
             parts.Add("Cursed");
@@ -208,6 +225,8 @@ public class ItemEffectEdit : BusinessBase<ItemEffectEdit>
             IconName = null;
             IsActive = true;
             Priority = 0;
+            IsToggleable = false;
+            ToggleApCost = 0;
         }
         BusinessRules.CheckRules();
     }
@@ -231,6 +250,8 @@ public class ItemEffectEdit : BusinessBase<ItemEffectEdit>
             IconName = dto.IconName;
             IsActive = dto.IsActive;
             Priority = dto.Priority;
+            IsToggleable = dto.IsToggleable;
+            ToggleApCost = dto.ToggleApCost;
         }
         BusinessRules.CheckRules();
     }
@@ -255,7 +276,9 @@ public class ItemEffectEdit : BusinessBase<ItemEffectEdit>
             BehaviorState = BehaviorState,
             IconName = IconName,
             IsActive = IsActive,
-            Priority = Priority
+            Priority = Priority,
+            IsToggleable = IsToggleable,
+            ToggleApCost = ToggleApCost
         };
     }
 

--- a/Threa.Dal.SqlLite/TestDataSeeder.cs
+++ b/Threa.Dal.SqlLite/TestDataSeeder.cs
@@ -1003,6 +1003,113 @@ public class TestDataSeeder
                 MaxStackSize = 30,
                 Rarity = ItemRarity.Common,
                 Tags = "food,consumable"
+            },
+
+            // === IMPLANTS ===
+            new ItemTemplate
+            {
+                Id = 200,
+                Name = "Subdermal Armor Weave",
+                Description = "Woven carbon-fiber mesh implanted beneath the skin, providing passive ballistic protection.",
+                ShortDescription = "Subdermal armor +1",
+                ItemType = ItemType.Implant,
+                EquipmentSlot = EquipmentSlot.ImplantSubdermal,
+                Weight = 0.5m,
+                Volume = 0.01m,
+                Value = 15000,
+                Rarity = ItemRarity.Rare,
+                Tags = "implant,cybernetic,armor",
+                Effects =
+                [
+                    new ItemEffectDefinition
+                    {
+                        Id = 200,
+                        ItemTemplateId = 200,
+                        EffectType = EffectType.Buff,
+                        Name = "Subdermal Armor",
+                        Description = "+1 armor absorption (all types)",
+                        Trigger = ItemEffectTrigger.WhileEquipped,
+                        IsToggleable = false,
+                        BehaviorState = """{"EffectName":"Subdermal Armor","Description":"+1 armor absorption (all types)","ItemName":"Subdermal Armor Weave","Modifiers":[{"Type":0,"Target":"ArmorAbsorption","Value":1}]}"""
+                    }
+                ]
+            },
+            new ItemTemplate
+            {
+                Id = 201,
+                Name = "Wired Reflexes Mk.I",
+                Description = "Spinal neural accelerator that boosts reaction speed when activated. Draws significant power.",
+                ShortDescription = "Toggleable DEX +2",
+                ItemType = ItemType.Implant,
+                EquipmentSlot = EquipmentSlot.ImplantSpine,
+                Weight = 0.3m,
+                Volume = 0.01m,
+                Value = 25000,
+                Rarity = ItemRarity.Epic,
+                Tags = "implant,cybernetic,reflex",
+                Effects =
+                [
+                    new ItemEffectDefinition
+                    {
+                        Id = 201,
+                        ItemTemplateId = 201,
+                        EffectType = EffectType.Buff,
+                        Name = "Wired Reflexes",
+                        Description = "+2 DEX while active",
+                        Trigger = ItemEffectTrigger.WhileEquipped,
+                        IsToggleable = true,
+                        ToggleApCost = 1,
+                        BehaviorState = """{"EffectName":"Wired Reflexes","Description":"+2 DEX while active","ItemName":"Wired Reflexes Mk.I","Modifiers":[{"Type":0,"Target":"DEX","Value":2}]}"""
+                    }
+                ]
+            },
+            new ItemTemplate
+            {
+                Id = 202,
+                Name = "Retractable Mono-Blade",
+                Description = "A monomolecular-edged blade concealed in the forearm, extending from the back of the hand.",
+                ShortDescription = "Implant melee weapon",
+                ItemType = ItemType.Implant,
+                EquipmentSlot = EquipmentSlot.ImplantHandRight,
+                Weight = 0.8m,
+                Volume = 0.02m,
+                Value = 12000,
+                WeaponType = WeaponType.Dagger,
+                RelatedSkill = "Light Blades",
+                DamageClass = 2,
+                DamageType = "Cutting",
+                SVModifier = 1,
+                Rarity = ItemRarity.Rare,
+                Tags = "implant,cybernetic,weapon,melee"
+            },
+            new ItemTemplate
+            {
+                Id = 203,
+                Name = "Thermographic Optics",
+                Description = "Optical implant providing thermal vision overlay, enhancing awareness in darkness and through smoke.",
+                ShortDescription = "Toggleable ITT +2",
+                ItemType = ItemType.Implant,
+                EquipmentSlot = EquipmentSlot.ImplantOpticLeft,
+                Weight = 0.1m,
+                Volume = 0.001m,
+                Value = 18000,
+                Rarity = ItemRarity.Rare,
+                Tags = "implant,cybernetic,optic,awareness",
+                Effects =
+                [
+                    new ItemEffectDefinition
+                    {
+                        Id = 203,
+                        ItemTemplateId = 203,
+                        EffectType = EffectType.Buff,
+                        Name = "Thermographic Vision",
+                        Description = "+2 ITT (Awareness) while active",
+                        Trigger = ItemEffectTrigger.WhileEquipped,
+                        IsToggleable = true,
+                        ToggleApCost = 0,
+                        BehaviorState = """{"EffectName":"Thermographic Vision","Description":"+2 ITT (Awareness) while active","ItemName":"Thermographic Optics","Modifiers":[{"Type":0,"Target":"ITT","Value":2}]}"""
+                    }
+                ]
             }
         ];
     }

--- a/Threa.Dal/Dto/EquipmentSlot.cs
+++ b/Threa.Dal/Dto/EquipmentSlot.cs
@@ -124,6 +124,16 @@ public enum EquipmentSlot
     /// <summary>
     /// Hand/finger enhancement (separate from arm).
     /// </summary>
-    ImplantHandRight = 114
+    ImplantHandRight = 114,
+
+    /// <summary>
+    /// Foot/ankle cybernetic enhancement (left).
+    /// </summary>
+    ImplantFootLeft = 115,
+
+    /// <summary>
+    /// Foot/ankle cybernetic enhancement (right).
+    /// </summary>
+    ImplantFootRight = 116
 }
 

--- a/Threa.Dal/Dto/EquipmentSlotExtensions.cs
+++ b/Threa.Dal/Dto/EquipmentSlotExtensions.cs
@@ -104,6 +104,8 @@ public static class EquipmentSlotExtensions
             EquipmentSlot.ImplantOrgan => "Organ Implant",
             EquipmentSlot.ImplantHandLeft => "Left Hand Cybernetic",
             EquipmentSlot.ImplantHandRight => "Right Hand Cybernetic",
+            EquipmentSlot.ImplantFootLeft => "Left Foot Cybernetic",
+            EquipmentSlot.ImplantFootRight => "Right Foot Cybernetic",
             _ => slot.ToString()
         };
     }

--- a/Threa.Dal/Dto/ItemEffectDefinition.cs
+++ b/Threa.Dal/Dto/ItemEffectDefinition.cs
@@ -78,4 +78,14 @@ public class ItemEffectDefinition
     /// Priority for effect application order (higher = applied first).
     /// </summary>
     public int Priority { get; set; }
+
+    /// <summary>
+    /// Whether this effect can be toggled on/off by the player (e.g., activatable implants).
+    /// </summary>
+    public bool IsToggleable { get; set; }
+
+    /// <summary>
+    /// AP cost to toggle this effect on or off. 0 = free action.
+    /// </summary>
+    public int ToggleApCost { get; set; }
 }

--- a/Threa.Dal/Dto/ItemType.cs
+++ b/Threa.Dal/Dto/ItemType.cs
@@ -21,5 +21,6 @@ public enum ItemType
     Jewelry = 13,
     Shield = 14,
     Ammunition = 15,
-    AmmoContainer = 16
+    AmmoContainer = 16,
+    Implant = 17
 }

--- a/Threa/Threa.Client/Components/GameMaster/ItemEffectEditDialog.razor
+++ b/Threa/Threa.Client/Components/GameMaster/ItemEffectEditDialog.razor
@@ -95,6 +95,26 @@
         }
     </RadzenFieldset>
 
+    <!-- Activation Settings Section -->
+    <RadzenFieldset Text="Activation Settings" class="mb-3">
+        <div class="row">
+            <div class="col-6">
+                <RadzenCheckBox @bind-Value="Effect.IsToggleable" Name="isToggleable" />
+                <RadzenLabel Text="Player can toggle this effect on/off" Component="isToggleable" Style="margin-left: 8px" />
+                <div><small class="text-muted">For activatable implants or similar equipment</small></div>
+            </div>
+            @if (Effect.IsToggleable)
+            {
+                <div class="col-6">
+                    <RadzenLabel Text="Toggle AP Cost" Component="toggleApCost" />
+                    <RadzenNumeric @bind-Value="Effect.ToggleApCost" Name="toggleApCost" Style="width: 100%"
+                                   Min="0" Placeholder="0" />
+                    <small class="text-muted">0 = free action, 1+ = AP cost per toggle</small>
+                </div>
+            }
+        </div>
+    </RadzenFieldset>
+
     <!-- Effect Modifiers Section -->
     <RadzenFieldset Text="Effect Modifiers" class="mb-3">
         <ItemEffectModifiersEditor @bind-BehaviorState="Effect.BehaviorState" />

--- a/Threa/Threa.Client/Components/Pages/GameMaster/ItemEdit.razor
+++ b/Threa/Threa.Client/Components/Pages/GameMaster/ItemEdit.razor
@@ -151,7 +151,17 @@ else
                                         <select @bind="vm.Model.EquipmentSlot" class="form-control">
                                             @foreach (EquipmentSlot slot in Enum.GetValues(typeof(EquipmentSlot)))
                                             {
-                                                <option value="@slot">@slot</option>
+                                                @if (vm.Model.ItemType == ItemType.Implant)
+                                                {
+                                                    @if (slot == EquipmentSlot.None || slot.IsImplant())
+                                                    {
+                                                        <option value="@slot">@slot.GetDisplayName()</option>
+                                                    }
+                                                }
+                                                else
+                                                {
+                                                    <option value="@slot">@slot</option>
+                                                }
                                             }
                                         </select>
                                     </td>
@@ -449,6 +459,88 @@ else
                         }
                     </RadzenTabsItem>
                 }
+
+                    <!-- ========================== -->
+                    <!-- IMPLANT TAB -->
+                    <!-- ========================== -->
+                    @if (vm.Model.ItemType == ItemType.Implant)
+                    {
+                        <RadzenTabsItem Text="Implant">
+                            <div class="info-box mt-3">
+                                <strong>Implant Properties</strong>
+                            </div>
+                            <table class="table table-sm">
+                            <tbody>
+                                <tr>
+                                    <td>Implant is a Weapon</td>
+                                    <td>
+                                        <input type="checkbox" class="form-check-input"
+                                               checked="@(vm.Model.WeaponType != WeaponType.None)"
+                                               @onchange="OnImplantWeaponToggle" />
+                                        <small class="text-muted ms-2">Enable if this implant can be used as a weapon (e.g., retractable blade, built-in gun)</small>
+                                    </td>
+                                </tr>
+                                @if (vm.Model.WeaponType != WeaponType.None)
+                                {
+                                    <tr>
+                                        <td>Weapon Type</td>
+                                        <td>
+                                            <select @bind="vm.Model.WeaponType" class="form-control">
+                                                @foreach (WeaponType wtype in Enum.GetValues(typeof(WeaponType)))
+                                                {
+                                                    @if (wtype != WeaponType.None)
+                                                    {
+                                                        <option value="@wtype">@wtype</option>
+                                                    }
+                                                }
+                                            </select>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>Related Skill</td>
+                                        <td>
+                                            <select @bind="vm.Model.RelatedSkill" class="form-control">
+                                                <option value="">-- None --</option>
+                                                @if (availableSkills != null)
+                                                {
+                                                    @foreach (var skill in availableSkills)
+                                                    {
+                                                        <option value="@skill.Id">@skill.Name</option>
+                                                    }
+                                                }
+                                            </select>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>Damage Class (1-4)</td>
+                                        <td>
+                                            <select @bind="vm.Model.DamageClass" class="form-control">
+                                                <option value="1">1 - Normal weapons, human-scale combat</option>
+                                                <option value="2">2 - Vehicles, giant creatures (10x Class 1)</option>
+                                                <option value="3">3 - Armored vehicles, structures, dragons (10x Class 2)</option>
+                                                <option value="4">4 - Armored structures, high-end magic (10x Class 3)</option>
+                                            </select>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>Damage Type</td>
+                                        <td>
+                                            <select @bind="vm.Model.DamageType" class="form-control">
+                                                <option value="">-- None --</option>
+                                                @foreach (DamageType type in Enum.GetValues(typeof(DamageType)))
+                                                {
+                                                    <option value="@type.ToString()">@type.ToString()</option>
+                                                }
+                                            </select>
+                                        </td>
+                                    </tr>
+                                    <NumericSelectorRow Property="vm.GetPropertyInfo<int>(() => vm.Model.SVModifier)" />
+                                    <NumericSelectorRow Property="vm.GetPropertyInfo<int>(() => vm.Model.AVModifier)" />
+                                }
+                            </tbody>
+                        </table>
+                    </RadzenTabsItem>
+                    }
 
                     <!-- ========================== -->
                     <!-- ARMOR TAB -->
@@ -763,7 +855,7 @@ else
 
     // Computed properties for section visibility
     private bool ShowEquipmentSection => vm.Model?.ItemType is ItemType.Weapon or ItemType.Armor
-        or ItemType.Shield or ItemType.Jewelry or ItemType.Clothing;
+        or ItemType.Shield or ItemType.Jewelry or ItemType.Clothing or ItemType.Implant;
 
     private bool IsRangedWeaponType => vm.Model?.WeaponType is WeaponType.Bow or WeaponType.Crossbow
         or WeaponType.Pistol or WeaponType.Rifle or WeaponType.Shotgun or WeaponType.SMG
@@ -883,6 +975,25 @@ else
             vm.Model.MaxStackSize = 1;
         }
 
+        // Implants cannot be stackable; clear non-implant equipment slot
+        if (vm.Model.ItemType == ItemType.Implant)
+        {
+            vm.Model.IsStackable = false;
+            vm.Model.MaxStackSize = 1;
+            if (vm.Model.EquipmentSlot != EquipmentSlot.None && !vm.Model.EquipmentSlot.IsImplant())
+            {
+                vm.Model.EquipmentSlot = EquipmentSlot.None;
+            }
+        }
+
+        StateHasChanged();
+    }
+
+    private void OnImplantWeaponToggle(ChangeEventArgs e)
+    {
+        if (vm.Model == null) return;
+        var isWeapon = (bool)e.Value!;
+        vm.Model.WeaponType = isWeapon ? WeaponType.Dagger : WeaponType.None;
         StateHasChanged();
     }
 

--- a/Threa/Threa.Client/Components/Pages/GamePlay/ActivateImplantMode.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/ActivateImplantMode.razor
@@ -1,0 +1,194 @@
+@using GameMechanics.Effects
+@using Threa.Dal.Dto
+
+<div class="activate-implant-mode">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0"><i class="bi bi-cpu text-info"></i> Implant Management</h4>
+        <button class="btn btn-outline-secondary btn-sm" @onclick="Done">
+            <i class="bi bi-x-lg"></i> Done
+        </button>
+    </div>
+
+    @if (!string.IsNullOrEmpty(statusMessage))
+    {
+        <div class="alert @(isError ? "alert-danger" : "alert-success") alert-dismissible fade show" role="alert">
+            @statusMessage
+            <button type="button" class="btn-close" @onclick="() => statusMessage = null"></button>
+        </div>
+    }
+
+    <div class="mb-2">
+        <small class="text-muted">
+            <i class="bi bi-info-circle"></i>
+            Toggle implant effects on or off. AP cost is deducted per toggle.
+            Available AP: <strong>@(Character?.ActionPoints.Available ?? 0)</strong>
+        </small>
+    </div>
+
+    @foreach (var implant in GetToggleableImplants())
+    {
+        <div class="card mb-3">
+            <div class="card-header bg-info bg-opacity-10 d-flex justify-content-between align-items-center">
+                <div>
+                    <i class="bi bi-cpu me-1"></i>
+                    <strong>@(implant.Item.Template?.Name ?? "Unknown Implant")</strong>
+                    <span class="badge bg-secondary ms-2">@implant.Item.EquippedSlot.GetDisplayName()</span>
+                </div>
+            </div>
+            <div class="card-body p-0">
+                <div class="list-group list-group-flush">
+                    @foreach (var effect in implant.ToggleableEffects)
+                    {
+                        var isActive = IsEffectActive(implant.Item.Id, effect);
+                        var canAfford = effect.ToggleApCost == 0 || (Character?.ActionPoints.Available ?? 0) >= effect.ToggleApCost;
+                        <div class="list-group-item d-flex justify-content-between align-items-center">
+                            <div>
+                                <strong>@effect.Name</strong>
+                                @if (!string.IsNullOrEmpty(effect.Description))
+                                {
+                                    <div class="small text-muted">@effect.Description</div>
+                                }
+                                <div class="small">
+                                    @if (effect.ToggleApCost > 0)
+                                    {
+                                        <span class="badge bg-warning text-dark me-1">@effect.ToggleApCost AP</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="badge bg-success me-1">Free</span>
+                                    }
+                                    @if (isActive)
+                                    {
+                                        <span class="badge bg-info">ON</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="badge bg-secondary">OFF</span>
+                                    }
+                                </div>
+                            </div>
+                            <div>
+                                @if (isActive)
+                                {
+                                    <button class="btn btn-sm btn-outline-danger"
+                                            disabled="@(isToggling || !canAfford)"
+                                            @onclick="() => ToggleOff(implant.Item.Id, effect)">
+                                        <i class="bi bi-toggle2-on"></i> Deactivate
+                                    </button>
+                                }
+                                else
+                                {
+                                    <button class="btn btn-sm btn-outline-success"
+                                            disabled="@(isToggling || !canAfford)"
+                                            @onclick="() => ToggleOn(implant.Item.Id, effect)">
+                                        <i class="bi bi-toggle2-off"></i> Activate
+                                    </button>
+                                }
+                                @if (!canAfford && effect.ToggleApCost > 0)
+                                {
+                                    <div class="small text-danger mt-1">Insufficient AP</div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public GameMechanics.CharacterEdit? Character { get; set; }
+
+    [Parameter]
+    public List<CharacterItem>? EquippedItems { get; set; }
+
+    [Parameter]
+    public required ItemEffectService ImplantEffectService { get; set; }
+
+    [Parameter]
+    public EventCallback OnComplete { get; set; }
+
+    [Parameter]
+    public EventCallback OnCharacterChanged { get; set; }
+
+    private string? statusMessage;
+    private bool isError;
+    private bool isToggling;
+
+    private record ImplantInfo(CharacterItem Item, List<ItemEffectDefinition> ToggleableEffects);
+
+    private List<ImplantInfo> GetToggleableImplants()
+    {
+        if (EquippedItems == null) return [];
+
+        return EquippedItems
+            .Where(i => i.EquippedSlot.IsImplant() &&
+                        i.Template?.ItemType == ItemType.Implant &&
+                        i.Template?.Effects?.Any(e => e.IsActive && e.IsToggleable) == true)
+            .Select(i => new ImplantInfo(
+                i,
+                i.Template!.Effects.Where(e => e.IsActive && e.IsToggleable).ToList()))
+            .ToList();
+    }
+
+    private bool IsEffectActive(Guid itemId, ItemEffectDefinition effectDef)
+    {
+        if (Character == null) return false;
+        return Character.Effects.Any(e => e.SourceItemId == itemId && e.Name == effectDef.Name);
+    }
+
+    private async Task ToggleOn(Guid itemId, ItemEffectDefinition effectDef)
+    {
+        if (Character == null) return;
+
+        isToggling = true;
+        statusMessage = null;
+
+        var result = await ImplantEffectService.ToggleImplantEffectOnAsync(Character, itemId, effectDef);
+        if (result.Success)
+        {
+            statusMessage = $"Activated: {effectDef.Name}";
+            isError = false;
+            await OnCharacterChanged.InvokeAsync();
+        }
+        else
+        {
+            statusMessage = result.ErrorMessage;
+            isError = true;
+        }
+
+        isToggling = false;
+        StateHasChanged();
+    }
+
+    private async Task ToggleOff(Guid itemId, ItemEffectDefinition effectDef)
+    {
+        if (Character == null) return;
+
+        isToggling = true;
+        statusMessage = null;
+
+        var result = ImplantEffectService.ToggleImplantEffectOff(Character, itemId, effectDef);
+        if (result.Success)
+        {
+            statusMessage = $"Deactivated: {effectDef.Name}";
+            isError = false;
+            await OnCharacterChanged.InvokeAsync();
+        }
+        else
+        {
+            statusMessage = result.ErrorMessage;
+            isError = true;
+        }
+
+        isToggling = false;
+        StateHasChanged();
+    }
+
+    private async Task Done()
+    {
+        await OnComplete.InvokeAsync();
+    }
+}

--- a/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
@@ -8,10 +8,13 @@
 @using Threa.Client.Components.Shared
 @using Threa.Client.Components.Pages.GamePlay.Targeting
 
+@using GameMechanics.Effects
+
 @inject ICharacterItemDal CharacterItemDal
 @inject IItemTemplateDal ItemTemplateDal
 @inject IActivityLogService ActivityLog
 @inject Radzen.DialogService DialogService
+@inject ItemEffectService ImplantEffectService
 
 <div class="combat-tab-container">
     @if (combatMode == CombatMode.Default)
@@ -174,6 +177,17 @@
                         <small class="opacity-75">First-Aid, Nursing, Doctor</small>
                     </button>
 
+                    @if (hasToggleableImplantsEquipped)
+                    {
+                        <!-- Implants Button -->
+                        <button class="btn btn-lg btn-outline-info py-3"
+                                @onclick="StartActivateImplant">
+                            <i class="bi bi-cpu fs-4"></i>
+                            <div class="fw-bold">IMPLANTS</div>
+                            <small class="opacity-75">Activate / Deactivate</small>
+                        </button>
+                    }
+
                     <!-- Rest Card -->
                     <div class="card">
                         <div class="card-body text-center">
@@ -310,6 +324,14 @@
                      OnMedicalComplete="OnMedicalComplete"
                      OnCharacterChanged="OnCharacterChanged" />
     }
+    else if (combatMode == CombatMode.ActivateImplant)
+    {
+        <ActivateImplantMode Character="Character"
+                             EquippedItems="equippedItems"
+                             ImplantEffectService="ImplantEffectService"
+                             OnComplete="OnActivateImplantComplete"
+                             OnCharacterChanged="OnCharacterChanged" />
+    }
     else if (combatMode == CombatMode.SelectTarget)
     {
         <div class="card">
@@ -345,7 +367,7 @@
     [Parameter]
     public EventCallback<(TargetingActionType ActionType, int TargetId, string TargetName, TargetingAttackerData AttackerData)> OnInitiateTargeting { get; set; }
 
-    private enum CombatMode { Default, Attack, Defend, TakeDamage, RangedAttack, Reload, Unload, Medical, SelectTarget }
+    private enum CombatMode { Default, Attack, Defend, TakeDamage, RangedAttack, Reload, Unload, Medical, SelectTarget, ActivateImplant }
     private CombatMode combatMode = CombatMode.Default;
 
     private List<GameMechanics.SkillEdit> filteredSkills = new();
@@ -363,6 +385,7 @@
     private string weaponSkillName = "";
     private List<RangedWeaponInfo> rangedWeapons = new();
     private List<AmmoSourceInfo> availableAmmoSources = new();
+    private bool hasToggleableImplantsEquipped;
 
     // Weapon modifiers for melee attacks (from equipped weapon template)
     private int meleeWeaponAVModifier;
@@ -491,11 +514,18 @@
         // Set hasWeaponEquipped to true if EITHER melee or ranged weapons are equipped
         hasWeaponEquipped = meleeWeapons.Any() || rangedWeapons.Any();
 
-        // Get equipped weapon skill names (exclude shields from weapons)
+        // Detect equipped implants with toggleable effects
+        hasToggleableImplantsEquipped = equippedItems.Any(i =>
+            i.EquippedSlot.IsImplant() &&
+            i.Template?.ItemType == ItemType.Implant &&
+            i.Template?.Effects?.Any(e => e.IsActive && e.IsToggleable) == true);
+
+        // Get equipped weapon skill names (exclude shields from weapons, include implant weapons)
         var weaponItems = equippedItems
             .Where(i => i.EquippedSlot == EquipmentSlot.MainHand ||
                        i.EquippedSlot == EquipmentSlot.TwoHand ||
-                       (i.EquippedSlot == EquipmentSlot.OffHand && i.Template?.ItemType != ItemType.Shield))
+                       (i.EquippedSlot == EquipmentSlot.OffHand && i.Template?.ItemType != ItemType.Shield) ||
+                       (i.EquippedSlot.IsImplant() && i.Template?.ItemType == ItemType.Implant && i.Template?.WeaponType != WeaponType.None))
             .ToList();
 
         // Collect skill names from both melee weapons (RelatedSkill) and ranged weapons (RangedSkill in CustomProperties)
@@ -685,6 +715,18 @@
         await LoadAvailableAmmoSources();
 
         combatMode = CombatMode.Reload;
+    }
+
+    private void StartActivateImplant()
+    {
+        combatMode = CombatMode.ActivateImplant;
+    }
+
+    private async Task OnActivateImplantComplete()
+    {
+        combatMode = CombatMode.Default;
+        await LoadEquipmentAndSkills();
+        StateHasChanged();
     }
 
     private void StartMedical()

--- a/Threa/Threa.Client/Components/Pages/GamePlay/TabPlayInventory.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/TabPlayInventory.razor
@@ -167,6 +167,15 @@
         letter-spacing: 0.05em;
     }
 
+    .slot-category.cybernetics h6 {
+        color: var(--bs-info, #0dcaf0);
+    }
+
+    .slot-category.cybernetics .equipment-slot {
+        border-left: 2px solid var(--bs-info, #0dcaf0);
+        padding-left: 12px;
+    }
+
     .equipment-slot.clickable {
         cursor: pointer;
     }
@@ -500,8 +509,14 @@
                 <div class="card-body equipment-slots-container">
                     @foreach (var category in slotCategories)
                     {
-                        <div class="slot-category">
-                            <h6 class="text-muted">@category.Name</h6>
+                        <div class="slot-category @(category.Name.StartsWith("Cybernetics") ? "cybernetics" : "")">
+                            <h6 class="text-muted">
+                                @if (category.Name.StartsWith("Cybernetics"))
+                                {
+                                    <i class="bi bi-cpu me-1"></i>
+                                }
+                                @category.Name
+                            </h6>
                             @foreach (var slot in category.Slots)
                             {
                                 var equipped = GetEquippedItem(slot);
@@ -625,6 +640,23 @@
             EquipmentSlot.FingerRight1, EquipmentSlot.FingerRight2,
             EquipmentSlot.FingerRight3, EquipmentSlot.FingerRight4,
             EquipmentSlot.FingerRight5
+        }),
+        new SlotCategory("Cybernetics - Head", new[] {
+            EquipmentSlot.ImplantNeural,
+            EquipmentSlot.ImplantOpticLeft, EquipmentSlot.ImplantOpticRight,
+            EquipmentSlot.ImplantAuralLeft, EquipmentSlot.ImplantAuralRight
+        }),
+        new SlotCategory("Cybernetics - Body", new[] {
+            EquipmentSlot.ImplantCardiac, EquipmentSlot.ImplantSpine,
+            EquipmentSlot.ImplantSubdermal, EquipmentSlot.ImplantOrgan
+        }),
+        new SlotCategory("Cybernetics - Arms", new[] {
+            EquipmentSlot.ImplantArmLeft, EquipmentSlot.ImplantArmRight,
+            EquipmentSlot.ImplantHandLeft, EquipmentSlot.ImplantHandRight
+        }),
+        new SlotCategory("Cybernetics - Legs", new[] {
+            EquipmentSlot.ImplantLegLeft, EquipmentSlot.ImplantLegRight,
+            EquipmentSlot.ImplantFootLeft, EquipmentSlot.ImplantFootRight
         })
     };
 


### PR DESCRIPTION
## Summary
- **Complete implant lifecycle**: GM creates implant items with effects → player equips to cybernetic slots → effects apply → toggleable implants activate/deactivate as combat actions → implant weapons work in combat → unequip removes effects
- **Data model**: `ItemType.Implant`, foot implant slots, `IsToggleable`/`ToggleApCost` on effect definitions, CSLA business object updates
- **GM editor**: Implant tab with weapon toggle, implant-only slot filtering, toggle activation fields in effect editor
- **Player inventory**: 4 cybernetics slot categories (Head, Body, Arms, Legs) with visual distinction
- **Combat integration**: New `ActivateImplantMode` component for toggling effects on/off with AP cost, `WeaponSelector` finds implant weapons for melee/ranged combat
- **Seed data**: 4 sample implants (Subdermal Armor, Wired Reflexes, Retractable Blade, Thermographic Optics)
- **14 new tests** covering toggle on/off, AP deduction, equip/unequip, weapon selection — all 1089 tests pass

## Test plan
- [ ] `dotnet build Threa.sln` compiles clean
- [ ] `dotnet test GameMechanics.Test` — all 1089 tests pass (14 new ImplantTests)
- [ ] GM creates implant with always-on effect → player equips → effect appears on character
- [ ] GM creates toggleable implant → player equips → no auto-effect → player hits IMPLANTS in combat → toggles on → effect applies → toggles off → effect removed
- [ ] GM creates implant weapon → player equips → weapon appears in combat attack options
- [ ] Player unequips any implant → all effects from that implant removed
- [ ] Toggle with AP cost properly deducts AP and is disabled when insufficient AP

🤖 Generated with [Claude Code](https://claude.com/claude-code)