### PR TITLE
Fix targeted ranged attack: filter fire modes and consume ammo (#167)

### DIFF
--- a/GameMechanics/Messaging/TargetingMessages.cs
+++ b/GameMechanics/Messaging/TargetingMessages.cs
@@ -205,6 +205,22 @@ public class TargetingAttackerData
     /// </summary>
     public List<MeleeWeaponInfo>? AvailableWeapons { get; init; }
 
+    // === Ranged weapon identity/capability (populated by CombatContent for ranged attacks) ===
+
+    /// <summary>
+    /// CharacterItem ID of the ranged weapon being used.
+    /// </summary>
+    public Guid WeaponItemId { get; init; }
+
+    /// <summary>Whether the weapon supports single-shot fire.</summary>
+    public bool SupportsSingle { get; init; } = true;
+
+    /// <summary>Whether the weapon supports burst fire.</summary>
+    public bool SupportsBurst { get; init; }
+
+    /// <summary>Whether the weapon supports suppressive fire.</summary>
+    public bool SupportsSuppression { get; init; }
+
     /// <summary>
     /// Gets a WeaponDamageProfile from per-type modifiers or legacy single-type data.
     /// </summary>
@@ -367,6 +383,23 @@ public class TargetingResolutionData
     /// Breakdown of defense calculation.
     /// </summary>
     public string DefenseBreakdown { get; init; } = string.Empty;
+
+    // === Ranged ammo tracking ===
+
+    /// <summary>
+    /// CharacterItem ID of the weapon used (ranged attacks only).
+    /// </summary>
+    public Guid WeaponItemId { get; init; }
+
+    /// <summary>
+    /// Number of rounds consumed by this attack.
+    /// </summary>
+    public int AmmoConsumed { get; init; }
+
+    /// <summary>
+    /// Rounds remaining in the weapon after this attack.
+    /// </summary>
+    public int AmmoRemaining { get; init; }
 }
 
 /// <summary>

--- a/Threa/Threa.Client/Components/Pages/GamePlay/Play.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/Play.razor
@@ -1518,7 +1518,7 @@ private async Task LoadTableCharactersAsync()
         // Ignore if not our table or disposed
         if (_disposed || table == null || e.TableId != table.Id) return;
 
-        _ = InvokeAsync(() =>
+        _ = InvokeAsync(async () =>
         {
             // If we have this interaction open, update it
             if (currentTargetingInteraction != null && e.InteractionId == currentTargetingInteraction.InteractionId)
@@ -1527,6 +1527,16 @@ private async Task LoadTableCharactersAsync()
                 if (interaction != null)
                 {
                     currentTargetingInteraction = interaction;
+                }
+
+                // Deduct ammo when we're the attacker in a ranged targeting interaction
+                if (isTargetingAttacker &&
+                    currentTargetingInteraction?.AttackerData.ActionType == TargetingActionType.RangedAttack &&
+                    currentTargetingInteraction?.Resolution != null &&
+                    tabCombatRef != null)
+                {
+                    var res = currentTargetingInteraction.Resolution;
+                    await tabCombatRef.HandleTargetedRangedAmmoUpdateAsync(res.WeaponItemId, res.AmmoRemaining);
                 }
             }
 

--- a/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/TabCombat.razor
@@ -64,4 +64,11 @@
     /// is pressed while a combat mode is active.
     /// </summary>
     public void ResetCombatMode() => combatContentRef?.ResetToDefault();
+
+    /// <summary>
+    /// Forwards ammo-update after a targeted ranged attack to the CombatContent component.
+    /// </summary>
+    public Task HandleTargetedRangedAmmoUpdateAsync(Guid weaponItemId, int ammoRemaining)
+        => combatContentRef?.HandleTargetedRangedAmmoUpdateAsync(weaponItemId, ammoRemaining)
+           ?? Task.CompletedTask;
 }

--- a/Threa/Threa.Client/Components/Pages/GamePlay/Targeting/TargetingAttackerPanel.razor
+++ b/Threa/Threa.Client/Components/Pages/GamePlay/Targeting/TargetingAttackerPanel.razor
@@ -69,10 +69,21 @@
 
             @if (ActionType == TargetingActionType.RangedAttack)
             {
+                <!-- Weapon name + ammo badge -->
+                @if (InitialData?.WeaponName != null)
+                {
+                    <div class="mb-3 d-flex justify-content-between align-items-center">
+                        <strong>@InitialData.WeaponName</strong>
+                        <span class="badge @(InitialData.CurrentLoadedAmmo > 0 ? "bg-success" : "bg-danger")">
+                            @InitialData.CurrentLoadedAmmo ammo
+                        </span>
+                    </div>
+                }
+
                 <!-- Ranged Attack Options -->
                 <div class="mb-3">
                     <label class="form-label fw-bold">Range</label>
-                    <select class="form-select form-select-sm" 
+                    <select class="form-select form-select-sm"
                             disabled="@IsReadOnly"
                             @bind="range" @bind:after="OnDataChanged">
                         <option value="@RangeCategory.Short">Short (TV 6)</option>
@@ -86,13 +97,35 @@
                 {
                     <div class="mb-3">
                         <label class="form-label fw-bold">Fire Mode</label>
-                        <select class="form-select form-select-sm" 
-                                disabled="@IsReadOnly"
-                                @bind="fireMode" @bind:after="OnDataChanged">
-                            <option value="@FireMode.Single">Single Shot</option>
-                            <option value="@FireMode.Burst">Burst (3 rounds)</option>
-                            <option value="@FireMode.Suppression">Suppression (10 rounds)</option>
-                        </select>
+                        <div class="d-flex flex-wrap gap-2">
+                            @if (InitialData?.SupportsSingle ?? true)
+                            {
+                                <button class="btn btn-sm @(fireMode == FireMode.Single ? "btn-warning" : "btn-outline-secondary")"
+                                        disabled="@IsReadOnly"
+                                        @onclick="() => SetFireMode(FireMode.Single)">
+                                    <i class="bi bi-dot"></i> Single
+                                    <span class="badge bg-dark">1 round</span>
+                                </button>
+                            }
+                            @if (InitialData?.SupportsBurst ?? false)
+                            {
+                                <button class="btn btn-sm @(fireMode == FireMode.Burst ? "btn-warning" : "btn-outline-secondary")"
+                                        disabled="@IsReadOnly"
+                                        @onclick="() => SetFireMode(FireMode.Burst)">
+                                    <i class="bi bi-three-dots"></i> Burst
+                                    <span class="badge bg-dark">@(InitialData?.BurstSize ?? 3) rounds</span>
+                                </button>
+                            }
+                            @if (InitialData?.SupportsSuppression ?? false)
+                            {
+                                <button class="btn btn-sm @(fireMode == FireMode.Suppression ? "btn-warning" : "btn-outline-secondary")"
+                                        disabled="@IsReadOnly"
+                                        @onclick="() => SetFireMode(FireMode.Suppression)">
+                                    <i class="bi bi-arrows-angle-expand"></i> Suppression
+                                    <span class="badge bg-dark">@(InitialData?.SuppressiveRounds ?? 10) rounds</span>
+                                </button>
+                            }
+                        </div>
                     </div>
                 }
             }
@@ -251,7 +284,18 @@
             apBoost = InitialData.APBoost;
             fatBoost = InitialData.FATBoost;
             range = InitialData.Range ?? RangeCategory.Medium;
-            fireMode = InitialData.FireMode ?? FireMode.Single;
+            // Auto-select fire mode based on weapon capabilities when not yet set
+            if (InitialData.FireMode.HasValue)
+            {
+                fireMode = InitialData.FireMode.Value;
+            }
+            else
+            {
+                if (InitialData.SupportsSingle) fireMode = FireMode.Single;
+                else if (InitialData.SupportsBurst) fireMode = FireMode.Burst;
+                else if (InitialData.SupportsSuppression) fireMode = FireMode.Suppression;
+                else fireMode = FireMode.Single;
+            }
             actionCostType = InitialData.ActionCostType;
 
             // Weapons are embedded in InitialData by CombatContent.BuildAttackerData —
@@ -369,7 +413,17 @@
             UsePhysicality = usePhysicality,
             Range = ActionType == TargetingActionType.RangedAttack ? range : null,
             FireMode = ActionType == TargetingActionType.RangedAttack ? fireMode : null,
-            AvailableWeapons = InitialData?.AvailableWeapons
+            AvailableWeapons = InitialData?.AvailableWeapons,
+            WeaponItemId = InitialData?.WeaponItemId ?? Guid.Empty,
+            SupportsSingle = InitialData?.SupportsSingle ?? true,
+            SupportsBurst = InitialData?.SupportsBurst ?? false,
+            SupportsSuppression = InitialData?.SupportsSuppression ?? false
         };
+    }
+
+    private async Task SetFireMode(FireMode mode)
+    {
+        fireMode = mode;
+        await OnDataChanged();
     }
 }

--- a/Threa/Threa.Client/Components/Shared/CombatContent.razor
+++ b/Threa/Threa.Client/Components/Shared/CombatContent.razor
@@ -1321,6 +1321,50 @@
         await InvokeAsync(StateHasChanged);
     }
 
+    /// <summary>
+    /// Called by Play.razor after a targeted ranged attack resolves to deduct ammo from the weapon.
+    /// Uses the same DB-update logic as OnRangedAttackComplete.
+    /// </summary>
+    public async Task HandleTargetedRangedAmmoUpdateAsync(Guid weaponItemId, int ammoRemaining)
+    {
+        if (weaponItemId == Guid.Empty) return;
+
+        var weapon = rangedWeapons.FirstOrDefault(w => w.ItemId == weaponItemId);
+        if (weapon != null)
+        {
+            weapon.LoadedAmmo = ammoRemaining;
+
+            var item = equippedItems.FirstOrDefault(i => i.Id == weaponItemId);
+            if (item != null)
+            {
+                var ammoState = WeaponAmmoState.FromJson(item.CustomProperties);
+                var previousAmmo = ammoState.LoadedAmmo;
+                ammoState.LoadedAmmo = ammoRemaining;
+                item.CustomProperties = WeaponAmmoState.MergeIntoCustomProperties(item.CustomProperties, ammoState);
+                await CharacterItemDal.UpdateItemAsync(item);
+
+                if (ammoState.LoadedMagazineId.HasValue)
+                {
+                    var magazineItem = await CharacterItemDal.GetItemAsync(ammoState.LoadedMagazineId.Value);
+                    if (magazineItem != null)
+                    {
+                        var magazineState = AmmoContainerState.FromJson(magazineItem.CustomProperties);
+                        var ammoConsumed = previousAmmo - ammoRemaining;
+                        magazineState.LoadedAmmo = Math.Max(0, magazineState.LoadedAmmo - ammoConsumed);
+                        magazineItem.CustomProperties = AmmoContainerState.MergeIntoCustomProperties(magazineItem.CustomProperties, magazineState);
+                        await CharacterItemDal.UpdateItemAsync(magazineItem);
+
+                        var cachedMag = availableAmmoSources.FirstOrDefault(a => a.ItemId == ammoState.LoadedMagazineId.Value);
+                        if (cachedMag != null)
+                            cachedMag.CurrentAmmo = magazineState.LoadedAmmo;
+                    }
+                }
+            }
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
     private async Task OnReloadComplete(ReloadCompleteData data)
     {
         LogActivity(data.Message, ActivityCategory.Combat);
@@ -1680,6 +1724,10 @@
         int weaponTemplateId = 0;
 
         string? ammoSpecialEffect = null;
+        Guid rangedWeaponItemId = Guid.Empty;
+        bool supportsSingle = true;
+        bool supportsBurst = false;
+        bool supportsSuppression = false;
 
         if (actionType == TargetingActionType.RangedAttack && rangedWeapons.Any())
         {
@@ -1693,6 +1741,10 @@
             currentAmmo = weapon.LoadedAmmo;
             weaponTemplateId = weapon.TemplateId;
             ammoSpecialEffect = weapon.LoadedAmmoSpecialEffect;
+            rangedWeaponItemId = weapon.ItemId;
+            supportsSingle = weapon.SupportsSingle;
+            supportsBurst = weapon.SupportsBurst;
+            supportsSuppression = weapon.SupportsSuppression;
         }
         else if (actionType == TargetingActionType.MeleeAttack)
         {
@@ -1737,7 +1789,11 @@
             WeaponTemplateId = weaponTemplateId,
             AttackerCharacterId = Character?.Id ?? 0,
             AmmoSpecialEffect = ammoSpecialEffect,
-            AvailableWeapons = actionType == TargetingActionType.MeleeAttack ? new List<MeleeWeaponInfo>(meleeWeaponOptions) : null
+            AvailableWeapons = actionType == TargetingActionType.MeleeAttack ? new List<MeleeWeaponInfo>(meleeWeaponOptions) : null,
+            WeaponItemId = rangedWeaponItemId,
+            SupportsSingle = supportsSingle,
+            SupportsBurst = supportsBurst,
+            SupportsSuppression = supportsSuppression
         };
     }
 

--- a/Threa/Threa/Services/TargetingInteractionManager.cs
+++ b/Threa/Threa/Services/TargetingInteractionManager.cs
@@ -625,6 +625,14 @@ public class TargetingInteractionManager : ITargetingInteractionManager
             defenderDetails += $"\nHit Location: {hitLocation}\nDamage: {fatDamage} FAT, {vitDamage} VIT";
         }
 
+        int ammoConsumed = attackerData.FireMode switch
+        {
+            FireMode.Burst => attackerData.BurstSize,
+            FireMode.Suppression => attackerData.SuppressiveRounds,
+            _ => 1
+        };
+        int ammoRemaining = Math.Max(0, attackerData.CurrentLoadedAmmo - ammoConsumed);
+
         return new TargetingResolutionData
         {
             AttackerAV = av,
@@ -639,7 +647,10 @@ public class TargetingInteractionManager : ITargetingInteractionManager
             AttackerNarrative = attackerNarrative,
             DefenderDetails = defenderDetails,
             AttackBreakdown = attackBreakdown,
-            DefenseBreakdown = defenseBreakdown
+            DefenseBreakdown = defenseBreakdown,
+            WeaponItemId = attackerData.WeaponItemId,
+            AmmoConsumed = ammoConsumed,
+            AmmoRemaining = ammoRemaining
         };
     }
 


### PR DESCRIPTION
## Summary

- **Fire mode filter**: `TargetingAttackerPanel` now shows only fire modes supported by the weapon (Single/Burst/Suppression buttons) instead of always showing all three options in a dropdown — matching the `RangedAttackMode` UI pattern
- **Ammo display**: Weapon name and loaded ammo count badge are now shown in the attacker panel for ranged attacks
- **Ammo consumption**: After a targeted ranged attack resolves, ammo is deducted from the weapon (and its loaded magazine if applicable) in the DB — same logic as anonymous ranged attacks

## Changes

| File | Change |
|------|--------|
| `GameMechanics/Messaging/TargetingMessages.cs` | Add `WeaponItemId`, `SupportsSingle/Burst/Suppression` to `TargetingAttackerData`; add `WeaponItemId`, `AmmoConsumed`, `AmmoRemaining` to `TargetingResolutionData` |
| `TargetingInteractionManager.cs` | Compute ammo consumed/remaining in `ResolveRangedAttack` and return with resolution data |
| `CombatContent.razor` | Populate new weapon identity/capability fields in `BuildAttackerData`; add public `HandleTargetedRangedAmmoUpdateAsync` |
| `TargetingAttackerPanel.razor` | Replace fire-mode `<select>` with filtered buttons; add weapon name + ammo badge; auto-select default fire mode |
| `TabCombat.razor` | Expose `HandleTargetedRangedAmmoUpdateAsync` delegate |
| `Play.razor` | Call ammo update in `OnTargetingResultReceived` when attacker resolves a ranged targeting attack |

## Test plan

- [ ] Navigate to play page with a character that has a ranged weapon loaded
- [ ] Select "Ranged Target" and pick a target — confirm only supported fire modes appear
- [ ] Confirm weapon name and ammo count badge are displayed in the attacker panel
- [ ] Complete the attack and verify ammo is deducted (visible in Inventory tab and on next targeting)
- [ ] Test a weapon that supports only Single — confirm Burst/Suppression buttons do not appear
- [ ] Test a weapon that supports multiple fire modes — confirm all supported modes appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)