### PR TITLE
Update NuGet dependencies (stay on CSLA 9.x) + patch SQLitePCLRaw vuln

### DIFF
--- a/GameMechanics.Messaging.InMemory/GameMechanics.Messaging.InMemory.csproj
+++ b/GameMechanics.Messaging.InMemory/GameMechanics.Messaging.InMemory.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GameMechanics.Test/GameMechanics.Test.csproj
+++ b/GameMechanics.Test/GameMechanics.Test.csproj
@@ -11,15 +11,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Csla" Version="9.1.0" />
+    <PackageReference Include="Csla" Version="9.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GameMechanics/GameMechanics.csproj
+++ b/GameMechanics/GameMechanics.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla" Version="9.1.0" />
-    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="Csla" Version="9.1.1" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageReference Include="Profanity.Detector" Version="0.1.8" />
   </ItemGroup>
 

--- a/Threa.Admin/ItemImport/ItemExportCommands.cs
+++ b/Threa.Admin/ItemImport/ItemExportCommands.cs
@@ -36,7 +36,7 @@ public class ExportItemsCommand : AsyncCommand<ExportItemSettings>
 
     public ExportItemsCommand(IItemTemplateDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, ExportItemSettings settings)
+    protected override ValidationResult Validate(CommandContext context, ExportItemSettings settings)
     {
         if (string.IsNullOrWhiteSpace(settings.OutputDirectory))
             return ValidationResult.Error("Output directory is required");
@@ -44,7 +44,7 @@ public class ExportItemsCommand : AsyncCommand<ExportItemSettings>
         return ValidationResult.Success();
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, ExportItemSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ExportItemSettings settings, CancellationToken cancellationToken)
     {
         // Ensure directory exists
         if (!Directory.Exists(settings.OutputDirectory))

--- a/Threa.Admin/ItemImport/ItemImportCommands.cs
+++ b/Threa.Admin/ItemImport/ItemImportCommands.cs
@@ -28,10 +28,10 @@ public class ImportItemsCommand : AsyncCommand<ImportItemSettings>
 
     public ImportItemsCommand(IItemTemplateDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
+    protected override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
         => ImportValidation.ValidateFilePath(settings.FilePath);
 
-    public override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings, CancellationToken cancellationToken)
     {
         var items = CsvImportHelper.ReadCsv<ItemTemplate, BaseItemCsvMap>(settings.FilePath);
         if (items == null) return 1;
@@ -64,10 +64,10 @@ public class ImportWeaponsCommand : AsyncCommand<ImportItemSettings>
 
     public ImportWeaponsCommand(IItemTemplateDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
+    protected override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
         => ImportValidation.ValidateFilePath(settings.FilePath);
 
-    public override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings, CancellationToken cancellationToken)
     {
         var items = CsvImportHelper.ReadCsv<ItemTemplate, WeaponCsvMap>(settings.FilePath);
         if (items == null) return 1;
@@ -108,10 +108,10 @@ public class ImportArmorCommand : AsyncCommand<ImportItemSettings>
 
     public ImportArmorCommand(IItemTemplateDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
+    protected override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
         => ImportValidation.ValidateFilePath(settings.FilePath);
 
-    public override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings, CancellationToken cancellationToken)
     {
         var rows = CsvImportHelper.ReadCsv<ArmorImportRow, ArmorImportCsvMap>(settings.FilePath);
         if (rows == null) return 1;
@@ -175,10 +175,10 @@ public class ImportRangedWeaponsCommand : AsyncCommand<ImportItemSettings>
 
     public ImportRangedWeaponsCommand(IItemTemplateDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
+    protected override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
         => ImportValidation.ValidateFilePath(settings.FilePath);
 
-    public override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings, CancellationToken cancellationToken)
     {
         var rows = CsvImportHelper.ReadCsv<RangedWeaponImportRow, RangedWeaponImportCsvMap>(settings.FilePath);
         if (rows == null) return 1;
@@ -303,10 +303,10 @@ public class ImportAmmoCommand : AsyncCommand<ImportItemSettings>
 
     public ImportAmmoCommand(IItemTemplateDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
+    protected override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
         => ImportValidation.ValidateFilePath(settings.FilePath);
 
-    public override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings, CancellationToken cancellationToken)
     {
         var rows = CsvImportHelper.ReadCsv<AmmoImportRow, AmmoImportCsvMap>(settings.FilePath);
         if (rows == null) return 1;
@@ -375,10 +375,10 @@ public class ImportAmmoContainersCommand : AsyncCommand<ImportItemSettings>
 
     public ImportAmmoContainersCommand(IItemTemplateDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
+    protected override ValidationResult Validate(CommandContext context, ImportItemSettings settings)
         => ImportValidation.ValidateFilePath(settings.FilePath);
 
-    public override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ImportItemSettings settings, CancellationToken cancellationToken)
     {
         var rows = CsvImportHelper.ReadCsv<AmmoContainerImportRow, AmmoContainerImportCsvMap>(settings.FilePath);
         if (rows == null) return 1;

--- a/Threa.Admin/Program.cs
+++ b/Threa.Admin/Program.cs
@@ -187,7 +187,7 @@ public class CreateCommand : AsyncCommand<CreateSettings>
 
     public CreateCommand(IPlayerDal dal) => _dal = dal;
 
-    public override async Task<int> ExecuteAsync(CommandContext context, CreateSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, CreateSettings settings, CancellationToken cancellationToken)
     {
         // Check if user already exists
         var existing = await _dal.GetPlayerByEmailAsync(settings.Email);
@@ -237,7 +237,7 @@ public class ListCommand : AsyncCommand<CommonSettings>
 
     public ListCommand(IPlayerDal dal) => _dal = dal;
 
-    public override async Task<int> ExecuteAsync(CommandContext context, CommonSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, CommonSettings settings, CancellationToken cancellationToken)
     {
         var players = await _dal.GetAllPlayersAsync();
 
@@ -285,7 +285,7 @@ public class RolesCommand : AsyncCommand<EmailSettings>
 
     public RolesCommand(IPlayerDal dal) => _dal = dal;
 
-    public override async Task<int> ExecuteAsync(CommandContext context, EmailSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, EmailSettings settings, CancellationToken cancellationToken)
     {
         var player = await _dal.GetPlayerByEmailAsync(settings.Email);
 
@@ -330,7 +330,7 @@ public class GrantCommand : AsyncCommand<RoleSettings>
 
     public GrantCommand(IPlayerDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, RoleSettings settings)
+    protected override ValidationResult Validate(CommandContext context, RoleSettings settings)
     {
         if (!IsValidRole(settings.Role))
         {
@@ -339,7 +339,7 @@ public class GrantCommand : AsyncCommand<RoleSettings>
         return ValidationResult.Success();
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, RoleSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, RoleSettings settings, CancellationToken cancellationToken)
     {
         var player = await _dal.GetPlayerByEmailAsync(settings.Email);
 
@@ -397,7 +397,7 @@ public class RevokeCommand : AsyncCommand<RoleSettings>
 
     public RevokeCommand(IPlayerDal dal) => _dal = dal;
 
-    public override async Task<int> ExecuteAsync(CommandContext context, RoleSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, RoleSettings settings, CancellationToken cancellationToken)
     {
         var player = await _dal.GetPlayerByEmailAsync(settings.Email);
 
@@ -453,7 +453,7 @@ public class EnableCommand : AsyncCommand<EmailSettings>
 
     public EnableCommand(IPlayerDal dal) => _dal = dal;
 
-    public override async Task<int> ExecuteAsync(CommandContext context, EmailSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, EmailSettings settings, CancellationToken cancellationToken)
     {
         var player = await _dal.GetPlayerByEmailAsync(settings.Email);
 
@@ -483,7 +483,7 @@ public class DisableCommand : AsyncCommand<EmailSettings>
 
     public DisableCommand(IPlayerDal dal) => _dal = dal;
 
-    public override async Task<int> ExecuteAsync(CommandContext context, EmailSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, EmailSettings settings, CancellationToken cancellationToken)
     {
         var player = await _dal.GetPlayerByEmailAsync(settings.Email);
 
@@ -518,7 +518,7 @@ public class DeleteCommand : AsyncCommand<EmailSettings>
         _characterDal = characterDal;
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, EmailSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, EmailSettings settings, CancellationToken cancellationToken)
     {
         var player = await _playerDal.GetPlayerByEmailAsync(settings.Email);
         if (player == null)
@@ -561,7 +561,7 @@ public class SetPasswordCommand : AsyncCommand<PasswordSettings>
 
     public SetPasswordCommand(IPlayerDal dal) => _dal = dal;
 
-    public override async Task<int> ExecuteAsync(CommandContext context, PasswordSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, PasswordSettings settings, CancellationToken cancellationToken)
     {
         var player = await _dal.GetPlayerByEmailAsync(settings.Email);
 
@@ -622,7 +622,7 @@ public class ImportSkillsCommand : AsyncCommand<ImportSkillsSettings>
 
     public ImportSkillsCommand(ISkillDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, ImportSkillsSettings settings)
+    protected override ValidationResult Validate(CommandContext context, ImportSkillsSettings settings)
     {
         if (!File.Exists(settings.FilePath))
         {
@@ -638,7 +638,7 @@ public class ImportSkillsCommand : AsyncCommand<ImportSkillsSettings>
         return ValidationResult.Success();
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, ImportSkillsSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ImportSkillsSettings settings, CancellationToken cancellationToken)
     {
         var ext = Path.GetExtension(settings.FilePath).ToLowerInvariant();
         var delimiter = ext == ".tsv" ? "\t" : ",";
@@ -735,7 +735,7 @@ public class ExportSkillsCommand : AsyncCommand<FileSettings>
 
     public ExportSkillsCommand(ISkillDal dal) => _dal = dal;
 
-    public override ValidationResult Validate(CommandContext context, FileSettings settings)
+    protected override ValidationResult Validate(CommandContext context, FileSettings settings)
     {
         var ext = Path.GetExtension(settings.FilePath).ToLowerInvariant();
         if (ext != ".csv" && ext != ".tsv")
@@ -752,7 +752,7 @@ public class ExportSkillsCommand : AsyncCommand<FileSettings>
         return ValidationResult.Success();
     }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, FileSettings settings)
+    protected override async Task<int> ExecuteAsync(CommandContext context, FileSettings settings, CancellationToken cancellationToken)
     {
         var ext = Path.GetExtension(settings.FilePath).ToLowerInvariant();
         var delimiter = ext == ".tsv" ? "\t" : ",";

--- a/Threa.Admin/Threa.Admin.csproj
+++ b/Threa.Admin/Threa.Admin.csproj
@@ -14,10 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="33.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>

--- a/Threa.Admin/Threa.Admin.csproj
+++ b/Threa.Admin/Threa.Admin.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console" Version="0.57.2" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Threa.Dal.SqlLite/Threa.Dal.Sqlite.csproj
+++ b/Threa.Dal.SqlLite/Threa.Dal.Sqlite.csproj
@@ -7,10 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Pin SQLitePCLRaw to 3.x: 2.1.x has high-severity vuln GHSA-2m69-gcr7-jv3q -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Threa.Dal/Threa.Dal.csproj
+++ b/Threa.Dal/Threa.Dal.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla" Version="9.1.0" />
+    <PackageReference Include="Csla" Version="9.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Threa/Threa.Client/Threa.Client.csproj
+++ b/Threa/Threa.Client/Threa.Client.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Csla.Blazor" Version="9.1.1" />
     <PackageReference Include="Csla.Blazor.WebAssembly" Version="9.1.1" />
     <PackageReference Include="Markdig" Version="1.3.2" />
-    <PackageReference Include="Radzen.Blazor" Version="8.4.2" />
+    <PackageReference Include="Radzen.Blazor" Version="11.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Threa/Threa.Client/Threa.Client.csproj
+++ b/Threa/Threa.Client/Threa.Client.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
     <PackageReference Include="Csla.Blazor" Version="9.1.1" />
     <PackageReference Include="Csla.Blazor.WebAssembly" Version="9.1.1" />
-    <PackageReference Include="Markdig" Version="0.40.0" />
+    <PackageReference Include="Markdig" Version="1.3.2" />
     <PackageReference Include="Radzen.Blazor" Version="8.4.2" />
   </ItemGroup>
 

--- a/Threa/Threa.Client/Threa.Client.csproj
+++ b/Threa/Threa.Client/Threa.Client.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.1" />
-    <PackageReference Include="Csla.Blazor" Version="9.1.0" />
-    <PackageReference Include="Csla.Blazor.WebAssembly" Version="9.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageReference Include="Csla.Blazor" Version="9.1.1" />
+    <PackageReference Include="Csla.Blazor.WebAssembly" Version="9.1.1" />
     <PackageReference Include="Markdig" Version="0.40.0" />
     <PackageReference Include="Radzen.Blazor" Version="8.4.2" />
   </ItemGroup>

--- a/Threa/Threa/Threa.csproj
+++ b/Threa/Threa/Threa.csproj
@@ -45,15 +45,15 @@
     <ProjectReference Include="..\..\Threa.Dal.SqlLite\Threa.Dal.Sqlite.csproj" />
     <ProjectReference Include="..\..\Threa.Dal\Threa.Dal.csproj" />
     <ProjectReference Include="..\Threa.Client\Threa.Client.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.1" />
-    <PackageReference Include="Csla.AspNetCore" Version="9.1.0" />
-    <PackageReference Include="Csla.Blazor" Version="9.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
+    <PackageReference Include="Csla.AspNetCore" Version="9.1.1" />
+    <PackageReference Include="Csla.Blazor" Version="9.1.1" />
     <PackageReference Include="Radzen.Blazor" Version="8.4.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Threa/Threa/Threa.csproj
+++ b/Threa/Threa/Threa.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
     <PackageReference Include="Csla.AspNetCore" Version="9.1.1" />
     <PackageReference Include="Csla.Blazor" Version="9.1.1" />
-    <PackageReference Include="Radzen.Blazor" Version="8.4.2" />
+    <PackageReference Include="Radzen.Blazor" Version="11.1.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />


### PR DESCRIPTION
## Summary

Brings NuGet packages up to date after a long gap. All 8 projects were already targeting `net10.0` (no change needed). CSLA intentionally stays on the **9.x** line (9.1.0 → 9.1.1); the CSLA 10 upgrade is deferred to a separate PR.

## Changes (one commit each)

1. **Low-risk servicing/minor batch** + **security fix**
   - `Microsoft.Extensions.*` / `Microsoft.Data.Sqlite` / `Microsoft.AspNetCore.Components.*` → 10.0.9
   - `Microsoft.NET.Test.Sdk` → 18.7.0, `MSTest.*` → 4.3.0, `coverlet.collector` → 10.0.1
   - `BCrypt.Net-Next` → 4.2.0, `OpenTelemetry.*` → 1.16.0, `System.Reactive` → 6.1.0, `CsvHelper` → 33.1.0
   - `Csla*` → 9.1.1 (latest 9.x patch)
   - **Pinned `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3** to override the transitive 2.1.11 pulled by `Microsoft.Data.Sqlite`, which carries high-severity vuln [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q). Solution is now clean of vulnerable packages.
2. **Markdig** 0.40.0 → 1.3.2 (no code changes; API unchanged)
3. **Spectre.Console** 0.49.1 → 0.57.2 / `Spectre.Console.Cli` 0.49.1 → 0.55.0
   - Fixed breaking changes in the CLI command base class: `AsyncCommand<T>.ExecuteAsync` now takes a `CancellationToken`, and `Validate`/`ExecuteAsync` overrides are now `protected`. Updated all command classes in `Threa.Admin`.
4. **Radzen.Blazor** 8.4.2 → 11.1.2 (three majors; **zero source changes required**)

## Verification

- `dotnet build Threa.sln` → **0 errors**
- `dotnet test` → **1359 passed, 0 failed**
- `dotnet list package --vulnerable` → clean across all 8 projects
- `threa-admin --help` runs and lists all commands
- **Radzen browser walkthrough** (registered a user, created a character, exercised the Items tab): RadzenDataGrid (data/sort/pagination), RadzenDropDown (popup + filtering), RadzenNumeric, RadzenTextBox, tabs, equip/unequip flow, and material icons/CSS all render correctly with **zero browser console errors**.

## Deferred
- **CSLA 9 → 10** (kept on 9.x by request)
- Radzen combat-dialog views behind an activated-character/campaign flow weren't driven interactively (heavier game setup), but the dialog host and all other component families are verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
