### PR TITLE
Upgrade CSLA 9.1.1 -> 10.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ private set => LoadProperty(AttributeListProperty, value);
 private async Task FetchAsync(int id, [Inject] ICharacterDal dal, ...) { ... }
 ```
 
-**Use the CSLA MCP server** (`csla-framework-developer` agent) for guidance on CSLA-specific patterns and best practices. This project uses CSLA version 9.
+**Use the CSLA MCP server** (`csla-framework-developer` agent) for guidance on CSLA-specific patterns and best practices. This project uses CSLA version 10 (query the MCP server with `version: 10`). The v9-style manual `GetProperty`/`SetProperty` property pattern remains fully supported; the v10 `[CslaImplementProperties]` partial-property code generation is optional.
 
 ## Code Conventions
 
@@ -124,9 +124,9 @@ private async Task FetchAsync(int id, [Inject] ICharacterDal dal, ...) { ... }
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| `Csla` | 9.1.0 | Core business object framework |
-| `Csla.AspNetCore` | 9.1.0 | ASP.NET Core integration |
-| `Csla.Blazor` | 9.1.0 | Blazor integration |
+| `Csla` | 10.1.0 | Core business object framework |
+| `Csla.AspNetCore` | 10.1.0 | ASP.NET Core integration |
+| `Csla.Blazor` | 10.1.0 | Blazor integration |
 | `Radzen.Blazor` | 8.4.2 | UI component library |
 
 **Important**: When updating CSLA packages, update all CSLA packages together to maintain version compatibility.

--- a/GameMechanics.Test/EffectTemplateSerializationTests.cs
+++ b/GameMechanics.Test/EffectTemplateSerializationTests.cs
@@ -1,8 +1,9 @@
 using System;
-using System.Threading.Tasks;
+using Csla.Configuration;
+using Csla.Serialization;
+using Csla.Serialization.Mobile;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Csla;
-using GameMechanics;
 using Threa.Dal.Dto;
 
 namespace GameMechanics.Test;
@@ -10,26 +11,36 @@ namespace GameMechanics.Test;
 [TestClass]
 public class EffectTemplateSerializationTests
 {
+    /// <summary>
+    /// Builds a minimal CSLA service provider and returns the configured
+    /// serialization formatter (MobileFormatter by default). CSLA 10 no longer
+    /// allows constructing <see cref="SerializationInfo"/> directly, so tests
+    /// must round-trip objects through the real formatter.
+    /// </summary>
+    private static ISerializationFormatter CreateFormatter(out ServiceProvider provider)
+    {
+        var services = new ServiceCollection();
+        services.AddCsla();
+        provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<ISerializationFormatter>();
+    }
+
     [TestMethod]
     public void EffectTemplateDto_ImplementsIMobileObject()
     {
-        // Arrange
         var dto = new EffectTemplateDto();
 
-        // Assert - Check that it's an IMobileObject by trying to use its methods
-        var info = new Csla.Serialization.Mobile.SerializationInfo();
-
-        // This will throw if IMobileObject is not properly implemented
-        dto.GetState(info);
-
-        // Success - the DTO implements IMobileObject
-        Assert.IsTrue(true, "EffectTemplateDto properly implements IMobileObject");
+        Assert.IsInstanceOfType<IMobileObject>(dto,
+            "EffectTemplateDto must implement IMobileObject to be serialized by MobileFormatter.");
     }
 
     [TestMethod]
     public void EffectTemplateDto_CanSerializeAndDeserialize()
     {
         // Arrange
+        var formatter = CreateFormatter(out var provider);
+        using var _ = provider;
+
         var original = new EffectTemplateDto
         {
             Id = 123,
@@ -48,12 +59,9 @@ public class EffectTemplateSerializationTests
             UpdatedAt = new DateTime(2026, 1, 15, 14, 30, 0, DateTimeKind.Utc)
         };
 
-        // Act - Manually serialize and deserialize
-        var info = new Csla.Serialization.Mobile.SerializationInfo();
-        original.GetState(info);
-
-        var deserialized = new EffectTemplateDto();
-        deserialized.SetState(info);
+        // Act - round-trip through the configured MobileFormatter
+        var data = formatter.Serialize(original);
+        var deserialized = (EffectTemplateDto)formatter.Deserialize(data)!;
 
         // Assert - All properties should match
         Assert.AreEqual(original.Id, deserialized.Id);
@@ -70,7 +78,5 @@ public class EffectTemplateSerializationTests
         Assert.AreEqual(original.IsActive, deserialized.IsActive);
         Assert.AreEqual(original.CreatedAt, deserialized.CreatedAt);
         Assert.AreEqual(original.UpdatedAt, deserialized.UpdatedAt);
-
-        Console.WriteLine("SUCCESS: All properties correctly serialized and deserialized!");
     }
 }

--- a/GameMechanics.Test/GameMechanics.Test.csproj
+++ b/GameMechanics.Test/GameMechanics.Test.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Csla" Version="9.1.1" />
+    <PackageReference Include="Csla" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GameMechanics/GameMechanics.csproj
+++ b/GameMechanics/GameMechanics.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla" Version="9.1.1" />
+    <PackageReference Include="Csla" Version="10.1.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageReference Include="Profanity.Detector" Version="0.1.8" />
   </ItemGroup>

--- a/Threa.Dal/Threa.Dal.csproj
+++ b/Threa.Dal/Threa.Dal.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla" Version="9.1.1" />
+    <PackageReference Include="Csla" Version="10.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Threa/Threa.Client/Threa.Client.csproj
+++ b/Threa/Threa.Client/Threa.Client.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
-    <PackageReference Include="Csla.Blazor" Version="9.1.1" />
-    <PackageReference Include="Csla.Blazor.WebAssembly" Version="9.1.1" />
+    <PackageReference Include="Csla.Blazor" Version="10.1.0" />
+    <PackageReference Include="Csla.Blazor.WebAssembly" Version="10.1.0" />
     <PackageReference Include="Markdig" Version="1.3.2" />
     <PackageReference Include="Radzen.Blazor" Version="11.1.2" />
   </ItemGroup>

--- a/Threa/Threa/Threa.csproj
+++ b/Threa/Threa/Threa.csproj
@@ -46,8 +46,8 @@
     <ProjectReference Include="..\..\Threa.Dal\Threa.Dal.csproj" />
     <ProjectReference Include="..\Threa.Client\Threa.Client.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
-    <PackageReference Include="Csla.AspNetCore" Version="9.1.1" />
-    <PackageReference Include="Csla.Blazor" Version="9.1.1" />
+    <PackageReference Include="Csla.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Csla.Blazor" Version="10.1.0" />
     <PackageReference Include="Radzen.Blazor" Version="11.1.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />


### PR DESCRIPTION
## Summary

Upgrades CSLA .NET from **9.1.1 → 10.1.0** across all projects (`Csla`, `Csla.AspNetCore`, `Csla.Blazor`, `Csla.Blazor.WebAssembly`). This is the follow-up to #177, which intentionally stayed on the CSLA 9.x line.

Guidance for the upgrade came from the CSLA MCP knowledge base (v10 docs).

## Why it's a small diff

Per the v10 documentation, CSLA 10 keeps the **v9 manual `GetProperty`/`SetProperty` property pattern fully supported** — the new `[CslaImplementProperties]` partial-property code generation is opt-in. As a result, **none of the ~40 business objects, the DAL, or the Blazor UI needed source changes**; they compile against v10 unchanged.

The single break was in a unit test: CSLA 10 makes the parameterless `SerializationInfo()` constructor **obsolete-as-error** (it is now internal to `MobileFormatter`). `EffectTemplateSerializationTests` constructed it directly. Rewrote the test to round-trip the DTO through the configured `ISerializationFormatter` (MobileFormatter) — the v10-idiomatic approach — instead of hand-building `SerializationInfo`.

Also updated `CLAUDE.md` so its CSLA guidance references v10 (query the MCP server with `version: 10`) and notes the manual property pattern still works.

## Verification

- `dotnet build Threa.sln` → **0 errors**
- `dotnet test` → **1359 passed, 0 failed** (including the rewritten serialization tests)
- **Runtime data-portal smoke test** (live Blazor app on v10): logged in, fetched a character (CSLA `Fetch` + child object graph), renamed it, **Saved** (`Update` + n-level undo / MobileFormatter), reloaded, and confirmed the change persisted — with zero browser console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
